### PR TITLE
getDefaultMenu method

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
@@ -46,7 +46,7 @@ public class CosmeticCommand implements CommandExecutor {
             }
 
             CosmeticUser user = CosmeticUsers.getUser(((Player) sender).getUniqueId());
-            Menu menu = Menus.getMenu(Settings.getDefaultMenu());
+            Menu menu = Menus.getDefaultMenu();
 
             if (user == null) {
                 MessagesUtil.sendMessage(sender, "invalid-player");

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menus.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menus.java
@@ -39,6 +39,8 @@ public class Menus {
         return MENUS.containsValue(menu);
     }
 
+    public static Menu getDefaultMenu() { return MENUS.get(Settings.getDefaultMenu()); }
+
     public static List<String> getMenuNames() {
         List<String> names = new ArrayList<>();
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menus.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menus.java
@@ -39,7 +39,7 @@ public class Menus {
         return MENUS.containsValue(menu);
     }
 
-    public static Menu getDefaultMenu() { return MENUS.get(Settings.getDefaultMenu()); }
+    public static Menu getDefaultMenu() { return Menus.getMenu(Settings.getDefaultMenu()); }
 
     public static List<String> getMenuNames() {
         List<String> names = new ArrayList<>();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
@@ -13,7 +13,6 @@ import com.hibiscusmc.hmccosmetics.config.Settings;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticArmorType;
-import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticBackpackType;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticBalloonType;
 import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.gui.Menus;
@@ -356,7 +355,7 @@ public class PlayerGameListener implements Listener {
                 CosmeticUser user = CosmeticUsers.getUser(player);
                 if (user == null) return;
                 if (!user.isInWardrobe()) return;
-                Menu menu = Menus.getMenu(Settings.getDefaultMenu());
+                Menu menu = Menus.getDefaultMenu();
                 if (menu == null) return;
                 menu.openMenu(user);
                 event.setCancelled(true);


### PR DESCRIPTION
nothing important as it is just a shorthand method, but feels more normal to do:
```java
Menus.getDefaultMenu();
```
than
```java
Menus.getMenu(Settings.getDefaultMenu());
```