### PR TITLE
Major consistency changes

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/HMCCosmeticsPlugin.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/HMCCosmeticsPlugin.java
@@ -42,8 +42,6 @@ import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public final class HMCCosmeticsPlugin extends JavaPlugin {
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticSetupEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticSetupEvent.java
@@ -2,6 +2,7 @@ package com.hibiscusmc.hmccosmetics.api;
 
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class HMCCosmeticSetupEvent extends Event {
 
@@ -12,6 +13,7 @@ public class HMCCosmeticSetupEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
@@ -5,10 +5,11 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerCosmeticEquipEvent extends Event implements Cancellable {
 
-    private CosmeticUser user;
+    private final CosmeticUser user;
     private Cosmetic cosmetic;
     private boolean isCancelled;
 
@@ -31,6 +32,7 @@ public class PlayerCosmeticEquipEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }
@@ -47,7 +49,7 @@ public class PlayerCosmeticEquipEvent extends Event implements Cancellable {
         return cosmetic;
     }
 
-    public void setCosmetic() {
+    public void setCosmetic(Cosmetic cosmetic) {
         this.cosmetic = cosmetic;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
@@ -4,11 +4,12 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerCosmeticHideEvent extends Event implements Cancellable {
 
-    private CosmeticUser user;
-    private CosmeticUser.HiddenReason reason;
+    private final CosmeticUser user;
+    private final CosmeticUser.HiddenReason reason;
     private boolean isCancelled;
 
     public PlayerCosmeticHideEvent(CosmeticUser user, CosmeticUser.HiddenReason reason) {
@@ -30,6 +31,7 @@ public class PlayerCosmeticHideEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticRemoveEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticRemoveEvent.java
@@ -5,11 +5,12 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerCosmeticRemoveEvent extends Event implements Cancellable {
 
-    private CosmeticUser user;
-    private Cosmetic cosmetic;
+    private final CosmeticUser user;
+    private final Cosmetic cosmetic;
     private boolean isCancelled;
 
     public PlayerCosmeticRemoveEvent(CosmeticUser user, Cosmetic cosmetic) {
@@ -31,6 +32,7 @@ public class PlayerCosmeticRemoveEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
@@ -4,10 +4,11 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerCosmeticShowEvent extends Event implements Cancellable {
 
-    private CosmeticUser user;
+    private final CosmeticUser user;
     private boolean isCancelled;
 
     public PlayerCosmeticShowEvent(CosmeticUser user) {
@@ -28,6 +29,7 @@ public class PlayerCosmeticShowEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
@@ -5,11 +5,12 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerMenuOpenEvent extends Event implements Cancellable {
 
-    private CosmeticUser user;
-    private Menu menu;
+    private final CosmeticUser user;
+    private final Menu menu;
     private boolean isCancelled;
 
     public PlayerMenuOpenEvent(CosmeticUser user, Menu menu) {
@@ -31,6 +32,7 @@ public class PlayerMenuOpenEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
@@ -4,10 +4,11 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerWardrobeEnterEvent extends Event implements Cancellable {
 
-    private CosmeticUser user;
+    private final CosmeticUser user;
     private boolean isCancelled;
 
     public PlayerWardrobeEnterEvent(CosmeticUser user) {
@@ -28,6 +29,7 @@ public class PlayerWardrobeEnterEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
@@ -4,10 +4,11 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerWardrobeLeaveEvent extends Event implements Cancellable {
 
-    private CosmeticUser user;
+    private final CosmeticUser user;
     private boolean isCancelled;
 
     public PlayerWardrobeLeaveEvent(CosmeticUser user) {
@@ -28,6 +29,7 @@ public class PlayerWardrobeLeaveEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     @Override
+    @NotNull
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
@@ -34,7 +34,7 @@ public class CosmeticCommand implements CommandExecutor {
     //             0      1        2
 
     @Override
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
         boolean silent = false;
 
         if (args.length == 0) {
@@ -69,7 +69,10 @@ public class CosmeticCommand implements CommandExecutor {
 
         if (sender.hasPermission("HMCCosmetics.cmd.silent") || sender.isOp()) {
             for (String singleArg : args) {
-                if (singleArg.equalsIgnoreCase("-s")) silent = true;
+                if (singleArg.equalsIgnoreCase("-s")) {
+                    silent = true;
+                    break;
+                }
             }
         }
 
@@ -145,7 +148,7 @@ public class CosmeticCommand implements CommandExecutor {
                     return true;
                 }
 
-                CosmeticSlot cosmeticSlot = null;
+                CosmeticSlot cosmeticSlot;
 
                 if (sender instanceof Player) player = ((Player) sender).getPlayer();
                 if (sender.hasPermission("hmccosmetics.cmd.unapply.other")) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
@@ -322,7 +322,7 @@ public class CosmeticCommand implements CommandExecutor {
                 }
                 player.sendMessage("Passengers -> " + player.getPassengers());
                 if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
-                    player.sendMessage("Backpack Location -> " + user.getUserBackpackManager().getArmorstand().getLocation());
+                    player.sendMessage("Backpack Location -> " + user.getUserBackpackManager().getArmorStand().getLocation());
                 }
                 player.sendMessage("Cosmetics -> " + user.getCosmetic());
                 player.sendMessage("EntityId -> " + player.getEntityId());

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class CosmeticCommandTabComplete implements TabCompleter {
     @Nullable
     @Override
-    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String @NotNull [] args) {
         List<String> completions = new ArrayList<>();
         List<String> finalCompletions = new ArrayList<>();
 
@@ -115,7 +115,8 @@ public class CosmeticCommandTabComplete implements TabCompleter {
         return finalCompletions;
     }
 
-    private static List<String> applyCommandComplete(CosmeticUser user, String[] args) {
+    @NotNull
+    private static List<String> applyCommandComplete(CosmeticUser user, String @NotNull [] args) {
         List<String> completitions = new ArrayList<>();
 
         if (args.length == 2) {
@@ -134,7 +135,7 @@ public class CosmeticCommandTabComplete implements TabCompleter {
         return completitions;
     }
 
-    private boolean hasPermission(CommandSender sender, String permission) {
+    private boolean hasPermission(@NotNull CommandSender sender, String permission) {
         if (sender.isOp()) return true;
         if (sender.hasPermission(permission)) return true;
         return false;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetic.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetic.java
@@ -5,6 +5,7 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -19,7 +20,7 @@ public class Cosmetic {
     private CosmeticSlot slot;
     private boolean dyable;
 
-    protected Cosmetic(String id, ConfigurationNode config) {
+    protected Cosmetic(String id, @NotNull ConfigurationNode config) {
         this.id = id;
         if (!config.node("permission").virtual()) {
             this.permission = config.node("permission").getString();
@@ -58,8 +59,7 @@ public class Cosmetic {
     }
 
     public boolean requiresPermission() {
-        if (permission == null) return false;
-        return true;
+        return permission != null;
     }
 
     public void setId(String id) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetics.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetics.java
@@ -6,6 +6,8 @@ import com.hibiscusmc.hmccosmetics.config.Settings;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.*;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import org.apache.commons.lang3.EnumUtils;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.ConfigurationNode;
@@ -17,7 +19,7 @@ import java.util.logging.Level;
 
 public class Cosmetics {
 
-    private static HashBiMap<String, Cosmetic> COSMETICS = HashBiMap.create();
+    private static final HashBiMap<String, Cosmetic> COSMETICS = HashBiMap.create();
 
     public static void addCosmetic(Cosmetic cosmetic) {
         COSMETICS.put(cosmetic.getId(), cosmetic);
@@ -35,10 +37,14 @@ public class Cosmetics {
         return COSMETICS.get(id);
     }
 
+    @Contract(pure = true)
+    @NotNull
     public static Set<Cosmetic> values() {
         return COSMETICS.values();
     }
 
+    @Contract(pure = true)
+    @NotNull
     public static Set<String> keys() {
         return COSMETICS.keySet();
     }
@@ -76,7 +82,7 @@ public class Cosmetics {
         }
     }
 
-    private static void setupCosmetics(CommentedConfigurationNode config) {
+    private static void setupCosmetics(@NotNull CommentedConfigurationNode config) {
         for (ConfigurationNode cosmeticConfig : config.childrenMap().values()) {
             try {
                 String id = cosmeticConfig.key().toString();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticArmorType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticArmorType.java
@@ -7,11 +7,12 @@ import com.hibiscusmc.hmccosmetics.util.packets.PacketManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public class CosmeticArmorType extends Cosmetic {
 
-    private EquipmentSlot equipSlot;
+    private final EquipmentSlot equipSlot;
 
     public CosmeticArmorType(String id, ConfigurationNode config) {
         super(id, config);
@@ -20,7 +21,7 @@ public class CosmeticArmorType extends Cosmetic {
     }
 
     @Override
-    public void update(CosmeticUser user) {
+    public void update(@NotNull CosmeticUser user) {
         Player player = Bukkit.getPlayer(user.getUniqueId());
         if (player == null) return;
         if (equipSlot.equals(EquipmentSlot.OFF_HAND)) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBackpackType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBackpackType.java
@@ -6,11 +6,12 @@ import com.hibiscusmc.hmccosmetics.util.packets.PacketManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public class CosmeticBackpackType extends Cosmetic {
 
-    private String modelName;
+    private final String modelName;
     private ConfigurationNode config;
 
     public CosmeticBackpackType(String id, ConfigurationNode config) {
@@ -21,8 +22,10 @@ public class CosmeticBackpackType extends Cosmetic {
     }
 
     @Override
-    public void update(CosmeticUser user) {
+    public void update(@NotNull CosmeticUser user) {
         Player player = Bukkit.getPlayer(user.getUniqueId());
+        if (player == null) return;
+
         Location loc = player.getLocation().clone().add(0, 2, 0);
 
         if (user.isInWardrobe() || !user.isBackupSpawned()) return;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBackpackType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBackpackType.java
@@ -29,15 +29,15 @@ public class CosmeticBackpackType extends Cosmetic {
         Location loc = player.getLocation().clone().add(0, 2, 0);
 
         if (user.isInWardrobe() || !user.isBackupSpawned()) return;
-        if (loc.getWorld() != user.getUserBackpackManager().getArmorstand().getWorld()) {
-            user.getUserBackpackManager().getArmorstand().teleport(loc);
+        if (loc.getWorld() != user.getUserBackpackManager().getArmorStand().getWorld()) {
+            user.getUserBackpackManager().getArmorStand().teleport(loc);
         }
 
-        user.getUserBackpackManager().getArmorstand().teleport(loc);
+        user.getUserBackpackManager().getArmorStand().teleport(loc);
 
-        PacketManager.sendRidingPacket(player.getEntityId(), user.getUserBackpackManager().getFirstArmorstandId(), loc);
+        PacketManager.sendRidingPacket(player.getEntityId(), user.getUserBackpackManager().getFirstArmorStandId(), loc);
 
-        user.getUserBackpackManager().getArmorstand().setRotation(loc.getYaw(), loc.getPitch());
+        user.getUserBackpackManager().getArmorStand().setRotation(loc.getYaw(), loc.getPitch());
         user.getUserBackpackManager().showBackpack();
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBalloonType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBalloonType.java
@@ -9,6 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -16,7 +17,7 @@ import java.util.List;
 
 public class CosmeticBalloonType extends Cosmetic {
 
-    private String modelName;
+    private final String modelName;
     private List<String> dyableParts;
     //private HashMap<Animations, String> animationBalloons;
 
@@ -46,12 +47,14 @@ public class CosmeticBalloonType extends Cosmetic {
     }
 
     @Override
-    public void update(CosmeticUser user) {
+    public void update(@NotNull CosmeticUser user) {
         Player player = Bukkit.getPlayer(user.getUniqueId());
         UserBalloonManager userBalloonManager = user.getBalloonManager();
-        Location newLocation = player.getLocation();
-        if (player == null || userBalloonManager == null || newLocation == null) return;
+
+        if (player == null || userBalloonManager == null) return;
         if (user.isInWardrobe()) return;
+
+        Location newLocation = player.getLocation();
         Location currentLocation = user.getBalloonManager().getLocation();
         newLocation = newLocation.clone().add(Settings.getBalloonOffset());
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticEmoteType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticEmoteType.java
@@ -3,11 +3,12 @@ package com.hibiscusmc.hmccosmetics.cosmetic.types;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public class CosmeticEmoteType extends Cosmetic {
 
-    private String animationId;
+    private final String animationId;
 
     public CosmeticEmoteType(String id, ConfigurationNode config) {
         super(id, config);
@@ -21,7 +22,7 @@ public class CosmeticEmoteType extends Cosmetic {
         // Nothing
     }
 
-    public void run(CosmeticUser user) {
+    public void run(@NotNull CosmeticUser user) {
         user.getUserEmoteManager().playEmote(this);
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticMainhandType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticMainhandType.java
@@ -5,6 +5,7 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.PlayerUtils;
 import com.hibiscusmc.hmccosmetics.util.packets.PacketManager;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public class CosmeticMainhandType extends Cosmetic {
@@ -14,10 +15,9 @@ public class CosmeticMainhandType extends Cosmetic {
     }
 
     @Override
-    public void update(CosmeticUser user) {
+    public void update(@NotNull CosmeticUser user) {
         Player player = user.getPlayer();
 
         PacketManager.equipmentSlotUpdate(player.getEntityId(), user, getSlot(), PlayerUtils.getNearbyPlayers(player));
-
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/Database.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/Database.java
@@ -16,22 +16,20 @@ public class Database {
 
     private static Data data;
 
+    @Deprecated
     private static InternalData INTERNAL_DATA  = new InternalData();
-    private static MySQLData MYSQL_DATA = new MySQLData();
-    private static SQLiteData SQLITE_DATA = new SQLiteData();
+
+    private static final MySQLData MYSQL_DATA = new MySQLData();
+    private static final SQLiteData SQLITE_DATA = new SQLiteData();
 
     public Database() {
         String databaseType = DatabaseSettings.getDatabaseType();
         data = INTERNAL_DATA; // default
-        if (databaseType.equalsIgnoreCase("INTERNAL")) {
-            data = INTERNAL_DATA;
-        }
         if (databaseType.equalsIgnoreCase("MySQL")) {
             data = MYSQL_DATA;
         }
         if (databaseType.equalsIgnoreCase("sqlite")) {
             data = SQLITE_DATA;
-
         }
         MessagesUtil.sendDebugMessages("Database is " + data);
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/Data.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/Data.java
@@ -10,6 +10,7 @@ import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import org.apache.commons.lang3.EnumUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -36,7 +37,7 @@ public class Data {
         // Override
     }
     // BACKPACK=colorfulbackpack&RRGGBB,HELMET=niftyhat,BALLOON=colorfulballoon,CHESTPLATE=niftychestplate
-    public String steralizeData(CosmeticUser user) {
+    public String serializeData(@NotNull CosmeticUser user) {
         String data = "";
         if (user.getHidden()) {
             if (shouldHiddenSave(user.getHiddenReason())) {
@@ -56,7 +57,7 @@ public class Data {
         return data;
     }
 
-    public Map<CosmeticSlot, Map<Cosmetic, Color>> desteralizedata(CosmeticUser user, String raw) {
+    public Map<CosmeticSlot, Map<Cosmetic, Color>> deserializeData(CosmeticUser user, @NotNull String raw) {
         Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = new HashMap<>();
         boolean checkPermission = Settings.getForcePermissionJoin();
 
@@ -102,7 +103,7 @@ public class Data {
         return cosmetics;
     }
 
-    private boolean shouldHiddenSave(CosmeticUser.HiddenReason reason) {
+    private boolean shouldHiddenSave(CosmeticUser.@NotNull HiddenReason reason) {
         switch (reason) {
             case EMOTE, NONE -> {
                 return false;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/InternalData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/InternalData.java
@@ -14,6 +14,7 @@ import org.bukkit.persistence.PersistentDataType;
 import java.util.Map;
 import java.util.UUID;
 
+@Deprecated
 public class InternalData extends Data {
 
     NamespacedKey key = new NamespacedKey(HMCCosmeticsPlugin.getInstance(), "cosmetics");
@@ -27,7 +28,7 @@ public class InternalData extends Data {
     public void save(CosmeticUser user) {
         Player player = Bukkit.getPlayer(user.getUniqueId());
 
-        player.getPersistentDataContainer().set(key, PersistentDataType.STRING, steralizeData(user));
+        player.getPersistentDataContainer().set(key, PersistentDataType.STRING, serializeData(user));
     }
 
     @Override
@@ -38,7 +39,7 @@ public class InternalData extends Data {
         if (!player.getPersistentDataContainer().has(key, PersistentDataType.STRING)) return user;
         String rawData = player.getPersistentDataContainer().get(key, PersistentDataType.STRING);
 
-        Map<CosmeticSlot, Map<Cosmetic, Color>> a = desteralizedata(user, rawData);
+        Map<CosmeticSlot, Map<Cosmetic, Color>> a = deserializeData(user, rawData);
         for (Map<Cosmetic, Color> cosmeticColors : a.values()) {
             for (Cosmetic cosmetic : cosmeticColors.keySet()) {
                 Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -58,7 +58,7 @@ public class MySQLData extends Data {
             try {
                 PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);");
                 preparedSt.setString(1, user.getUniqueId().toString());
-                preparedSt.setString(2, steralizeData(user));
+                preparedSt.setString(2, serializeData(user));
                 preparedSt.executeUpdate();
             } catch (SQLException e) {
                 throw new RuntimeException(e);
@@ -82,7 +82,7 @@ public class MySQLData extends Data {
                 ResultSet rs = preparedStatement.executeQuery();
                 if (rs.next()) {
                     String rawData = rs.getString("COSMETICS");
-                    Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = desteralizedata(user, rawData);
+                    Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = deserializeData(user, rawData);
                     for (Map<Cosmetic, Color> cosmeticColors : cosmetics.values()) {
                         for (Cosmetic cosmetic : cosmeticColors.keySet()) {
                             Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
@@ -160,11 +160,7 @@ public class MySQLData extends Data {
 
     private boolean isConnectionOpen() {
         try {
-            if (connection == null || connection.isClosed()) {
-                return false;
-            } else {
-                return true;
-            }
+            return connection != null && !connection.isClosed();
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
@@ -52,7 +52,7 @@ public class SQLiteData extends Data {
             try {
                 PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);");
                 preparedSt.setString(1, user.getUniqueId().toString());
-                preparedSt.setString(2, steralizeData(user));
+                preparedSt.setString(2, serializeData(user));
                 preparedSt.executeUpdate();
             } catch (SQLException e) {
                 throw new RuntimeException(e);
@@ -76,7 +76,7 @@ public class SQLiteData extends Data {
                 ResultSet rs = preparedStatement.executeQuery();
                 if (rs.next()) {
                     String rawData = rs.getString("COSMETICS");
-                    Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = desteralizedata(user, rawData);
+                    Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = deserializeData(user, rawData);
                     for (Map<Cosmetic, Color> cosmeticColors : cosmetics.values()) {
                         for (Cosmetic cosmetic : cosmeticColors.keySet()) {
                             Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
@@ -114,9 +114,6 @@ public class SQLiteData extends Data {
         //Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
 
         //close Connection if still active
-        if (connection != null) {
-            //close();
-        }
 
         File dataFolder = new File(HMCCosmeticsPlugin.getInstance().getDataFolder(), "database.db");
 
@@ -151,11 +148,7 @@ public class SQLiteData extends Data {
 
     private boolean isConnectionOpen() {
         try {
-            if (connection == null || connection.isClosed()) {
-                return false;
-            } else {
-                return true;
-            }
+            return connection != null && !connection.isClosed();
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
@@ -17,6 +17,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -25,13 +27,13 @@ import java.util.List;
 
 public class Menu {
 
-    private String id;
-    private String title;
-    private int rows;
-    private ConfigurationNode config;
-    private String permissionNode;
+    private final String id;
+    private final String title;
+    private final int rows;
+    private final ConfigurationNode config;
+    private final String permissionNode;
 
-    public Menu(String id, ConfigurationNode config) {
+    public Menu(String id, @NotNull ConfigurationNode config) {
         this.id = id;
         this.config = config;
 
@@ -58,7 +60,7 @@ public class Menu {
         openMenu(user, false);
     }
 
-    public void openMenu(CosmeticUser user, boolean ignorePermission) {
+    public void openMenu(@NotNull CosmeticUser user, boolean ignorePermission) {
         Player player = user.getPlayer();
         if (player == null) return;
         if (!ignorePermission && !permissionNode.isEmpty()) {
@@ -97,7 +99,8 @@ public class Menu {
 
     }
 
-    private Gui getItems(CosmeticUser user, Gui gui) {
+    @Contract("_, _ -> param2")
+    private Gui getItems(@NotNull CosmeticUser user, Gui gui) {
         Player player = user.getPlayer();
 
         for (ConfigurationNode config : config.node("items").childrenMap().values()) {
@@ -164,7 +167,8 @@ public class Menu {
         return gui;
     }
 
-    private List<Integer> getSlots(List<String> slotString) {
+    @NotNull
+    private List<Integer> getSlots(@NotNull List<String> slotString) {
         List<Integer> slots = new ArrayList<>();
 
         for (String a : slotString) {
@@ -181,6 +185,7 @@ public class Menu {
         return slots;
     }
 
+    @NotNull
     private List<Integer> getSlots(int small, int max) {
         List<Integer> slots = new ArrayList<>();
 
@@ -188,7 +193,9 @@ public class Menu {
         return slots;
     }
 
-    private ItemStack updateLore(CosmeticUser user, ItemStack itemStack, Type type, ConfigurationNode config) {
+    @Contract("_, _, _, _ -> param2")
+    @NotNull
+    private ItemStack updateLore(CosmeticUser user, @NotNull ItemStack itemStack, Type type, ConfigurationNode config) {
         if (itemStack.hasItemMeta()) {
             itemStack.setItemMeta(type.setLore(user, config, itemStack.getItemMeta()));
         }
@@ -201,7 +208,6 @@ public class Menu {
 
     public boolean canOpen(Player player) {
         if (permissionNode.isEmpty()) return true;
-        if (player.isOp() || player.hasPermission(permissionNode)) return true;
-        return false;
+        return player.isOp() || player.hasPermission(permissionNode);
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menus.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menus.java
@@ -4,6 +4,8 @@ import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.config.Settings;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
@@ -17,21 +19,23 @@ import java.util.logging.Level;
 
 public class Menus {
 
-    private static HashMap<String, Menu> MENUS = new HashMap<>();
+    private static final HashMap<String, Menu> MENUS = new HashMap<>();
 
     public static void addMenu(Menu menu) {
         MENUS.put(menu.getId().toUpperCase(), menu);
     }
 
-    public static Menu getMenu(String id) {
+    public static Menu getMenu(@NotNull String id) {
         return MENUS.get(id.toUpperCase());
     }
 
+    @Contract(pure = true)
+    @NotNull
     public static Collection<Menu> getMenu() {
         return MENUS.values();
     }
 
-    public static boolean hasMenu(String id) {
+    public static boolean hasMenu(@NotNull String id) {
         return MENUS.containsKey(id.toUpperCase());
     }
 
@@ -41,6 +45,7 @@ public class Menus {
 
     public static Menu getDefaultMenu() { return Menus.getMenu(Settings.getDefaultMenu()); }
 
+    @NotNull
     public static List<String> getMenuNames() {
         List<String> names = new ArrayList<>();
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/Action.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/Action.java
@@ -1,12 +1,13 @@
 package com.hibiscusmc.hmccosmetics.gui.action;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.jetbrains.annotations.NotNull;
 
 public class Action {
 
-    private String id;
+    private final String id;
 
-    public Action(String id) {
+    public Action(@NotNull String id) {
         this.id = id.toUpperCase();
         Actions.addAction(this);
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/Actions.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/Actions.java
@@ -4,13 +4,14 @@ import com.hibiscusmc.hmccosmetics.gui.action.actions.*;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.List;
 
 public class Actions {
 
-    private static HashMap<String, Action> actions = new HashMap<>();
+    private static final HashMap<String, Action> actions = new HashMap<>();
 
     // [ID]
     private static ActionMessage ACTION_MESSAGE = new ActionMessage();
@@ -27,11 +28,11 @@ public class Actions {
     private static ActionCosmeticToggle ACTION_TOGGLE = new ActionCosmeticToggle();
 
 
-    public static Action getAction(String id) {
+    public static Action getAction(@NotNull String id) {
         return actions.get(id.toUpperCase());
     }
 
-    public static boolean isAction(String id) {
+    public static boolean isAction(@NotNull String id) {
         return actions.containsKey(id.toUpperCase());
     }
 
@@ -39,7 +40,7 @@ public class Actions {
         actions.put(action.getId().toUpperCase(), action);
     }
 
-    public static void runActions(CosmeticUser user, List<String> raw) {
+    public static void runActions(CosmeticUser user, @NotNull List<String> raw) {
         for (String a : raw) {
             String id = StringUtils.substringBetween(a, "[", "]").toUpperCase();
             String message = StringUtils.substringAfter(a, "] ");

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCloseMenu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCloseMenu.java
@@ -2,6 +2,7 @@ package com.hibiscusmc.hmccosmetics.gui.action.actions;
 
 import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionCloseMenu extends Action {
 
@@ -10,7 +11,7 @@ public class ActionCloseMenu extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, String raw) {
         user.getPlayer().closeInventory();
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionConsoleCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionConsoleCommand.java
@@ -3,6 +3,7 @@ package com.hibiscusmc.hmccosmetics.gui.action.actions;
 import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionConsoleCommand extends Action {
 
@@ -11,7 +12,7 @@ public class ActionConsoleCommand extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, String raw) {
         HMCCosmeticsPlugin.getInstance().getServer().dispatchCommand(user.getPlayer(), raw);
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCosmeticHide.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCosmeticHide.java
@@ -2,6 +2,7 @@ package com.hibiscusmc.hmccosmetics.gui.action.actions;
 
 import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionCosmeticHide extends Action {
 
@@ -10,10 +11,9 @@ public class ActionCosmeticHide extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, String raw) {
         if (!user.getHidden()) {
             user.hideCosmetics(CosmeticUser.HiddenReason.ACTION);
-            return;
         }
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCosmeticShow.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCosmeticShow.java
@@ -2,6 +2,7 @@ package com.hibiscusmc.hmccosmetics.gui.action.actions;
 
 import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionCosmeticShow extends Action {
 
@@ -10,7 +11,7 @@ public class ActionCosmeticShow extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, String raw) {
         if (user.getHidden()) {
             if (user.getHiddenReason() != CosmeticUser.HiddenReason.ACTION && user.getHiddenReason() != CosmeticUser.HiddenReason.COMMAND) return; // Do not hide if its already off for WG
             user.showCosmetics();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCosmeticToggle.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionCosmeticToggle.java
@@ -2,6 +2,7 @@ package com.hibiscusmc.hmccosmetics.gui.action.actions;
 
 import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionCosmeticToggle extends Action {
 
@@ -10,13 +11,12 @@ public class ActionCosmeticToggle extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, String raw) {
         if (user.getHidden()) {
             if (user.getHiddenReason() != CosmeticUser.HiddenReason.ACTION && user.getHiddenReason() != CosmeticUser.HiddenReason.COMMAND) return;
             user.showCosmetics();
             return;
         }
         user.hideCosmetics(CosmeticUser.HiddenReason.ACTION);
-        return;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionMessage.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionMessage.java
@@ -3,6 +3,7 @@ package com.hibiscusmc.hmccosmetics.gui.action.actions;
 import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionMessage extends Action {
 
@@ -11,7 +12,7 @@ public class ActionMessage extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, String raw) {
         MessagesUtil.sendMessageNoKey(user.getPlayer(), raw);
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionParticle.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionParticle.java
@@ -5,7 +5,6 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import com.hibiscusmc.hmccosmetics.util.ServerUtils;
 import com.hibiscusmc.hmccosmetics.util.packets.PacketManager;
-import com.owen1212055.particlehelper.api.particle.Particle;
 import com.owen1212055.particlehelper.api.particle.types.BlockDataParticle;
 import com.owen1212055.particlehelper.api.particle.types.DestinationParticle;
 import com.owen1212055.particlehelper.api.particle.types.velocity.VelocityParticle;
@@ -14,6 +13,7 @@ import com.owen1212055.particlehelper.api.type.Particles;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionParticle extends Action {
 
@@ -22,7 +22,7 @@ public class ActionParticle extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(CosmeticUser user, @NotNull String raw) {
         String[] rawString = raw.split(" ");
         var particleType = Particles.fromKey(NamespacedKey.minecraft(rawString[0].toLowerCase()));
         if (particleType == null) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionPlayerCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionPlayerCommand.java
@@ -3,6 +3,7 @@ package com.hibiscusmc.hmccosmetics.gui.action.actions;
 import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
+import org.jetbrains.annotations.NotNull;
 
 public class ActionPlayerCommand extends Action {
 
@@ -11,7 +12,7 @@ public class ActionPlayerCommand extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, String raw) {
         user.getPlayer().performCommand(MessagesUtil.processStringNoKeyString(user.getPlayer(), raw));
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionSound.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/action/actions/ActionSound.java
@@ -4,6 +4,7 @@ import com.hibiscusmc.hmccosmetics.gui.action.Action;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.logging.Level;
 
@@ -15,7 +16,7 @@ public class ActionSound extends Action {
     }
 
     @Override
-    public void run(CosmeticUser user, String raw) {
+    public void run(@NotNull CosmeticUser user, @NotNull String raw) {
         Player player = user.getPlayer();
         String[] processedString = raw.split(" ");
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/special/DyeMenu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/special/DyeMenu.java
@@ -17,13 +17,12 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.jetbrains.annotations.NotNull;
 
 public class DyeMenu {
 
     // Yes, I do know how tacted on this feels.
-
-
-    public static void openMenu(CosmeticUser user, Cosmetic cosmetic) {
+    public static void openMenu(@NotNull CosmeticUser user, Cosmetic cosmetic) {
         ItemStack originalItem = user.getUserCosmeticItem(cosmetic);
         if (originalItem == null || !cosmetic.isDyable()) return;
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/Type.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/Type.java
@@ -7,7 +7,7 @@ import org.spongepowered.configurate.ConfigurationNode;
 
 public class Type {
 
-    private String id;
+    private final String id;
 
     public Type(String id) {
         this.id = id;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/Types.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/Types.java
@@ -2,21 +2,22 @@ package com.hibiscusmc.hmccosmetics.gui.type;
 
 import com.hibiscusmc.hmccosmetics.gui.type.types.TypeCosmetic;
 import com.hibiscusmc.hmccosmetics.gui.type.types.TypeEmpty;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 
 public class Types {
 
-    private static HashMap<String, Type> types = new HashMap<>();
+    private static final HashMap<String, Type> types = new HashMap<>();
 
     private static TypeCosmetic TYPE_COSMETIC = new TypeCosmetic();
     private static TypeEmpty TYPE_EMPTY = new TypeEmpty();
 
-    public static Type getType(String id) {
+    public static Type getType(@NotNull String id) {
         return types.get(id.toUpperCase());
     }
 
-    public static boolean isType(String id) {
+    public static boolean isType(@NotNull String id) {
         return types.containsKey(id.toUpperCase());
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeCosmetic.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeCosmetic.java
@@ -17,6 +17,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -31,7 +33,7 @@ public class TypeCosmetic extends Type {
     }
 
     @Override
-    public void run(CosmeticUser user, ConfigurationNode config, ClickType clickType) {
+    public void run(CosmeticUser user, @NotNull ConfigurationNode config, ClickType clickType) {
         if (config.node("cosmetic").virtual()) return;
         String cosmeticName = config.node("cosmetic").getString();
         Cosmetic cosmetic = Cosmetics.getCosmetic(cosmeticName);
@@ -92,7 +94,7 @@ public class TypeCosmetic extends Type {
     }
 
     @Override
-    public ItemMeta setLore(CosmeticUser user, ConfigurationNode config, ItemMeta itemMeta) {
+    public ItemMeta setLore(CosmeticUser user, @NotNull ConfigurationNode config, ItemMeta itemMeta) {
         List<String> processedLore = new ArrayList<>();
 
         if (config.node("cosmetic").virtual()) return processLoreLines(user, itemMeta);;
@@ -143,7 +145,9 @@ public class TypeCosmetic extends Type {
         return itemMeta;
     }
 
-    private ItemMeta processLoreLines(CosmeticUser user, ItemMeta itemMeta) {
+    @Contract("_, _ -> param2")
+    @NotNull
+    private ItemMeta processLoreLines(CosmeticUser user, @NotNull ItemMeta itemMeta) {
         List<String> processedLore = new ArrayList<>();
 
         if (itemMeta.hasLore()) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeEmpty.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeEmpty.java
@@ -8,6 +8,7 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -25,7 +26,7 @@ public class TypeEmpty extends Type {
 
     // This is the code that's run when the item is clicked.
     @Override
-    public void run(CosmeticUser user, ConfigurationNode config, ClickType clickType) {
+    public void run(CosmeticUser user, @NotNull ConfigurationNode config, ClickType clickType) {
         List<String> actionStrings = new ArrayList<>(); // List where we keep the actions the server will execute.
         ConfigurationNode actionConfig = config.node("actions"); // Configuration node that actions are under.
 
@@ -53,7 +54,7 @@ public class TypeEmpty extends Type {
     }
 
     @Override
-    public ItemMeta setLore(CosmeticUser user, ConfigurationNode config, ItemMeta itemMeta) {
+    public ItemMeta setLore(CosmeticUser user, ConfigurationNode config, @NotNull ItemMeta itemMeta) {
         List<String> processedLore = new ArrayList<>();
 
         if (itemMeta.hasLore()) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/Hook.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/Hook.java
@@ -5,7 +5,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class Hook implements Listener {
 
-    private String id;
+    private final String id;
     private boolean active;
     private boolean itemHook;
 
@@ -19,7 +19,7 @@ public class Hook implements Listener {
         // Override
     }
 
-    public ItemStack getItem(String itemid) {
+    public ItemStack getItem(String itemId) {
         return null;
         // Override
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/Hooks.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/Hooks.java
@@ -8,12 +8,14 @@ import com.hibiscusmc.hmccosmetics.hooks.placeholders.HookPlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 
 public class Hooks {
 
-    private static HashMap<String, Hook> hooks = new HashMap<>();
+    private static final HashMap<String, Hook> hooks = new HashMap<>();
     private static HookOraxen ORAXEN_HOOK = new HookOraxen();
     private static HookItemAdder ITEMADDER_HOOK = new HookItemAdder();
     private static HookLooty LOOTY_HOOK = new HookLooty();
@@ -23,11 +25,11 @@ public class Hooks {
     private static HookPremiumVanish PREMIUM_VANISH_HOOK = new HookPremiumVanish();
     private static HookSuperVanish SUPER_VANISH_HOOK = new HookSuperVanish();
 
-    public static Hook getHook(String id) {
+    public static Hook getHook(@NotNull String id) {
         return hooks.get(id.toLowerCase());
     }
 
-    public static boolean isItemHook(String id) {
+    public static boolean isItemHook(@NotNull String id) {
         return hooks.containsKey(id.toLowerCase());
     }
 
@@ -46,7 +48,8 @@ public class Hooks {
         }
     }
 
-    public static ItemStack getItem(String raw) {
+    @Nullable
+    public static ItemStack getItem(@NotNull String raw) {
         if (!raw.contains(":")) {
             Material mat = Material.getMaterial(raw.toUpperCase());
             if (mat == null) return null;
@@ -61,8 +64,7 @@ public class Hooks {
         Hook hook = getHook(split[0]);
         if (!hook.hasEnabledItemHook()) return null;
         if (!hook.getActive()) return null;
-        ItemStack item = hook.getItem(split[1]);
-        return item;
+        return hook.getItem(split[1]);
     }
 
     public static boolean isActiveHook(String id) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookHMCCosmetics.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookHMCCosmetics.java
@@ -14,8 +14,8 @@ public class HookHMCCosmetics extends Hook implements Listener {
     }
 
     @Override
-    public ItemStack getItem(String itemid) {
-        Cosmetic cosmetic = Cosmetics.getCosmetic(itemid);
+    public ItemStack getItem(String itemId) {
+        Cosmetic cosmetic = Cosmetics.getCosmetic(itemId);
         if (cosmetic == null) return null;
         return cosmetic.getItem();
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookItemAdder.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookItemAdder.java
@@ -21,9 +21,9 @@ public class HookItemAdder extends Hook implements Listener {
     }
 
     @Override
-    public ItemStack getItem(String itemid) {
+    public ItemStack getItem(String itemId) {
         if (enabled) {
-            CustomStack stack = CustomStack.getInstance(itemid);
+            CustomStack stack = CustomStack.getInstance(itemId);
             if (stack == null) return null;
             return stack.getItemStack();
         } else {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookLooty.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookLooty.java
@@ -14,8 +14,8 @@ public class HookLooty extends Hook implements Listener {
     }
 
     @Override
-    public ItemStack getItem(String itemid) {
-        PrefabKey prefabKey = PrefabKey.Companion.ofOrNull(itemid);
+    public ItemStack getItem(String itemId) {
+        PrefabKey prefabKey = PrefabKey.Companion.ofOrNull(itemId);
         if (prefabKey == null) return null;
         return LootyFactory.INSTANCE.createFromPrefab(prefabKey);
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookMythic.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookMythic.java
@@ -12,7 +12,7 @@ public class HookMythic extends Hook implements Listener {
     }
 
     @Override
-    public ItemStack getItem(String itemid) {
-        return MythicBukkit.inst().getItemManager().getItemStack(itemid);
+    public ItemStack getItem(String itemId) {
+        return MythicBukkit.inst().getItemManager().getItemStack(itemId);
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookOraxen.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookOraxen.java
@@ -14,8 +14,8 @@ public class HookOraxen extends Hook implements Listener {
     }
 
     @Override
-    public ItemStack getItem(String itemid) {
-        ItemBuilder builder = OraxenItems.getItemById(itemid);
+    public ItemStack getItem(String itemId) {
+        ItemBuilder builder = OraxenItems.getItemById(itemId);
         if (builder == null) return null;
         return builder.build();
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/misc/HookPremiumVanish.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/misc/HookPremiumVanish.java
@@ -8,6 +8,7 @@ import de.myzelyam.api.vanish.PlayerShowEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
 
 public class HookPremiumVanish extends Hook implements Listener {
 
@@ -18,7 +19,7 @@ public class HookPremiumVanish extends Hook implements Listener {
     }
 
     @EventHandler
-    public void onPlayerVanish(PlayerHideEvent event) {
+    public void onPlayerVanish(@NotNull PlayerHideEvent event) {
         Player player = event.getPlayer();
         CosmeticUser user = CosmeticUsers.getUser(player);
         if (user == null) return;
@@ -26,7 +27,7 @@ public class HookPremiumVanish extends Hook implements Listener {
     }
 
     @EventHandler
-    public void onPlayerShow(PlayerShowEvent event) {
+    public void onPlayerShow(@NotNull PlayerShowEvent event) {
         Player player = event.getPlayer();
         CosmeticUser user = CosmeticUsers.getUser(player);
         if (user == null) return;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/misc/HookSuperVanish.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/misc/HookSuperVanish.java
@@ -8,6 +8,7 @@ import de.myzelyam.api.vanish.PlayerShowEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
 
 public class HookSuperVanish extends Hook implements Listener {
 
@@ -18,7 +19,7 @@ public class HookSuperVanish extends Hook implements Listener {
     }
 
     @EventHandler
-    public void onPlayerVanish(PlayerHideEvent event) {
+    public void onPlayerVanish(@NotNull PlayerHideEvent event) {
         Player player = event.getPlayer();
         CosmeticUser user = CosmeticUsers.getUser(player);
         if (user == null) return;
@@ -26,7 +27,7 @@ public class HookSuperVanish extends Hook implements Listener {
     }
 
     @EventHandler
-    public void onPlayerShow(PlayerShowEvent event) {
+    public void onPlayerShow(@NotNull PlayerShowEvent event) {
         Player player = event.getPlayer();
         CosmeticUser user = CosmeticUsers.getUser(player);
         if (user == null) return;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/placeholders/HMCPlaceholderExpansion.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/placeholders/HMCPlaceholderExpansion.java
@@ -25,22 +25,25 @@ public class HMCPlaceholderExpansion extends PlaceholderExpansion {
     }
 
     @Override
-    public @NotNull String getIdentifier() {
+    @NotNull
+    public String getIdentifier() {
         return "HMCCosmetics";
     }
 
     @Override
-    public @NotNull String getAuthor() {
+    @NotNull
+    public String getAuthor() {
         return "HibiscusMC";
     }
 
     @Override
-    public @NotNull String getVersion() {
+    @NotNull
+    public String getVersion() {
         return HMCCosmeticsPlugin.getInstance().getDescription().getVersion();
     }
 
     @Override
-    public String onRequest(OfflinePlayer player, String params) {
+    public String onRequest(@NotNull OfflinePlayer player, @NotNull String params) {
         if (!player.isOnline()) return null;
         CosmeticUser user = CosmeticUsers.getUser(player.getPlayer());
         if (user == null) return null;
@@ -132,13 +135,13 @@ public class HMCPlaceholderExpansion extends PlaceholderExpansion {
         return null;
     }
 
-    public String getMaterial(Cosmetic cosmetic) {
+    public String getMaterial(@NotNull Cosmetic cosmetic) {
         ItemStack item = cosmetic.getItem();
         if (item == null) return null;
         return cosmetic.getItem().getType().toString();
     }
 
-    public String getModelData(Cosmetic cosmetic) {
+    public String getModelData(@NotNull Cosmetic cosmetic) {
         ItemStack item = cosmetic.getItem();
         if (item == null) return null;
         if (!item.hasItemMeta()) return null;
@@ -146,7 +149,7 @@ public class HMCPlaceholderExpansion extends PlaceholderExpansion {
         return String.valueOf(itemMeta.getCustomModelData());
     }
 
-    public String getItemName(Cosmetic cosmetic) {
+    public String getItemName(@NotNull Cosmetic cosmetic) {
         ItemStack item = cosmetic.getItem();
         if (item == null) return null;
         if (!item.hasItemMeta()) return null;
@@ -154,7 +157,7 @@ public class HMCPlaceholderExpansion extends PlaceholderExpansion {
         return itemMeta.getDisplayName();
     }
 
-    public String getItemLore(Cosmetic cosmetic) {
+    public String getItemLore(@NotNull Cosmetic cosmetic) {
         ItemStack item = cosmetic.getItem();
         if (item == null) return null;
         if (item.hasItemMeta()) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/worldguard/WGListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/worldguard/WGListener.java
@@ -12,11 +12,12 @@ import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class WGListener implements Listener {
 
     @EventHandler
-    public void onPlayerMove(PlayerMoveEvent event) {
+    public void onPlayerMove(@NotNull PlayerMoveEvent event) {
         CosmeticUser user = CosmeticUsers.getUser(event.getPlayer());
         if (user == null) return;
         Location location = event.getPlayer().getLocation();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerConnectionListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerConnectionListener.java
@@ -13,11 +13,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerConnectionListener implements Listener {
 
     @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
+    public void onPlayerJoin(@NotNull PlayerJoinEvent event) {
         if (event.getPlayer().isOp() || event.getPlayer().hasPermission("hmccosmetics.notifyupdate")) {
             if (!HMCCosmeticsPlugin.getLatestVersion().equalsIgnoreCase(HMCCosmeticsPlugin.getInstance().getDescription().getVersion()) && HMCCosmeticsPlugin.getLatestVersion() != null)
                 MessagesUtil.sendMessageNoKey(
@@ -46,7 +47,7 @@ public class PlayerConnectionListener implements Listener {
     }
 
     @EventHandler
-    public void onPlayerQuit(PlayerQuitEvent event) {
+    public void onPlayerQuit(@NotNull PlayerQuitEvent event) {
         CosmeticUser user = CosmeticUsers.getUser(event.getPlayer());
         if (user == null) { // Remove any passengers if a user failed to initialize. Bugs can cause this to happen
             if (!event.getPlayer().getPassengers().isEmpty()) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
@@ -23,7 +23,6 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUsers;
 import com.hibiscusmc.hmccosmetics.util.InventoryUtils;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import org.bukkit.Bukkit;
-import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -105,7 +104,7 @@ public class PlayerGameListener implements Listener {
         if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
             user.getUserBackpackManager().hideBackpack();
 
-            user.getUserBackpackManager().getArmorstand().teleport(event.getTo());
+            user.getUserBackpackManager().getArmorStand().teleport(event.getTo());
 
             Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
                 user.updateCosmetic();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/nms/NMSHandlers.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/nms/NMSHandlers.java
@@ -37,7 +37,6 @@ public class NMSHandlers {
             MessagesUtil.sendDebugMessages(packageVersion + " has been detected.", Level.INFO);
             version = packageVersion;
             try {
-                //Class.forName("org.bukkit.craftbukkit." + version + ".block.CraftBlock").getName();
                 handler = (NMSHandler) Class.forName("com.hibiscusmc.hmccosmetics.nms." + packageVersion + ".NMSHandler").getConstructor().newInstance();
                 return;
             } catch (ClassNotFoundException | InvocationTargetException | InstantiationException |

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -401,7 +401,7 @@ public class CosmeticUser {
             PacketManager.sendLeashPacket(getBalloonManager().getPufferfishBalloonId(), -1, viewer);
         }
         if (hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
-            userBackpackManager.getArmorstand().getEquipment().clear();
+            userBackpackManager.getArmorStand().getEquipment().clear();
         }
         updateCosmetic();
         MessagesUtil.sendDebugMessages("HideCosmetics");
@@ -427,7 +427,7 @@ public class CosmeticUser {
         if (hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
             CosmeticBackpackType cosmeticBackpackType = (CosmeticBackpackType) getCosmetic(CosmeticSlot.BACKPACK);
             ItemStack item = getUserCosmeticItem(cosmeticBackpackType);
-            userBackpackManager.getArmorstand().getEquipment().setHelmet(item);
+            userBackpackManager.getArmorStand().getEquipment().setHelmet(item);
         }
         updateCosmetic();
         MessagesUtil.sendDebugMessages("ShowCosmetics");

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
@@ -17,8 +17,8 @@ import java.util.logging.Level;
 public class UserBackpackManager {
 
     private boolean hideBackpack;
-    private ArmorStand invisibleArmorstand;
-    private CosmeticUser user;
+    private ArmorStand invisibleArmorStand;
+    private final CosmeticUser user;
     private BackpackType backpackType;
 
     public UserBackpackManager(CosmeticUser user) {
@@ -27,27 +27,27 @@ public class UserBackpackManager {
         backpackType = BackpackType.NORMAL;
     }
 
-    public int getFirstArmorstandId() {
-        return invisibleArmorstand.getEntityId();
+    public int getFirstArmorStandId() {
+        return invisibleArmorStand.getEntityId();
     }
 
-    public ArmorStand getArmorstand() {
-        return invisibleArmorstand;
+    public ArmorStand getArmorStand() {
+        return invisibleArmorStand;
     }
 
     public void spawnBackpack(CosmeticBackpackType cosmeticBackpackType) {
         MessagesUtil.sendDebugMessages("spawnBackpack Bukkit - Start");
 
-        if (this.invisibleArmorstand != null) return;
+        if (this.invisibleArmorStand != null) return;
 
-        this.invisibleArmorstand = (ArmorStand) NMSHandlers.getHandler().spawnBackpack(user, cosmeticBackpackType);
+        this.invisibleArmorStand = (ArmorStand) NMSHandlers.getHandler().spawnBackpack(user, cosmeticBackpackType);
 
         if (cosmeticBackpackType.getModelName() != null && HMCCosmeticsPlugin.hasModelEngine()) {
             if (ModelEngineAPI.api.getModelRegistry().getBlueprint(cosmeticBackpackType.getModelName()) == null) {
                 MessagesUtil.sendDebugMessages("Invalid Model Engine Blueprint " + cosmeticBackpackType.getModelName(), Level.SEVERE);
                 return;
             }
-            ModeledEntity modeledEntity = ModelEngineAPI.getOrCreateModeledEntity(invisibleArmorstand);
+            ModeledEntity modeledEntity = ModelEngineAPI.getOrCreateModeledEntity(invisibleArmorStand);
             ActiveModel model = ModelEngineAPI.createActiveModel(ModelEngineAPI.getBlueprint(cosmeticBackpackType.getModelName()));
             model.setCanHurt(false);
             modeledEntity.addModel(model, false);
@@ -57,23 +57,23 @@ public class UserBackpackManager {
     }
 
     public void despawnBackpack() {
-        if (invisibleArmorstand == null) return;
-        invisibleArmorstand.setHealth(0);
-        invisibleArmorstand.remove();
-        this.invisibleArmorstand = null;
+        if (invisibleArmorStand == null) return;
+        invisibleArmorStand.setHealth(0);
+        invisibleArmorStand.remove();
+        this.invisibleArmorStand = null;
     }
 
     public void hideBackpack() {
-        if (user.getHidden() == true) return;
-        getArmorstand().getEquipment().clear();
+        if (user.getHidden()) return;
+        getArmorStand().getEquipment().clear();
         hideBackpack = true;
     }
 
     public void showBackpack() {
-        if (hideBackpack == false) return;
+        if (!hideBackpack) return;
         CosmeticBackpackType cosmeticBackpackType = (CosmeticBackpackType) user.getCosmetic(CosmeticSlot.BACKPACK);
         ItemStack item = user.getUserCosmeticItem(cosmeticBackpackType);
-        getArmorstand().getEquipment().setHelmet(item);
+        getArmorStand().getEquipment().setHelmet(item);
         hideBackpack = false;
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBalloonManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBalloonManager.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 import java.util.logging.Level;
@@ -26,13 +27,13 @@ public class UserBalloonManager {
     private final UUID uniqueID;
     private final ArmorStand modelEntity;
 
-    public UserBalloonManager(Location location) {
+    public UserBalloonManager(@NotNull Location location) {
         this.uniqueID = UUID.randomUUID();
         this.balloonID = NMSHandlers.getHandler().getNextEntityId();
         this.modelEntity = NMSHandlers.getHandler().getMEGEntity(location.add(Settings.getBalloonOffset()));
     }
 
-    public void spawnModel(CosmeticBalloonType cosmeticBalloonType, Color color) {
+    public void spawnModel(@NotNull CosmeticBalloonType cosmeticBalloonType, Color color) {
         // redo this
         if (cosmeticBalloonType.getModelName() != null && HMCCosmeticsPlugin.hasModelEngine()) {
             balloonType = BalloonType.MODELENGINE;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteManager.java
@@ -3,6 +3,7 @@ package com.hibiscusmc.hmccosmetics.user.manager;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticEmoteType;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
+import org.jetbrains.annotations.NotNull;
 
 public class UserEmoteManager {
 
@@ -13,7 +14,7 @@ public class UserEmoteManager {
         this.user = user;
     }
 
-    public void playEmote(CosmeticEmoteType cosmeticEmoteType) {
+    public void playEmote(@NotNull CosmeticEmoteType cosmeticEmoteType) {
         MessagesUtil.sendDebugMessages("playEmote " + cosmeticEmoteType.getAnimationId());
         playEmote(cosmeticEmoteType.getAnimationId());
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteModel.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteModel.java
@@ -14,29 +14,27 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
 public class UserEmoteModel extends PlayerModel {
 
-    private CosmeticUser user;
+    private final CosmeticUser user;
     private String emotePlaying;
-    private int armorstandId;
+    private final int armorStandId;
     private GameMode originalGamemode;
 
-    public UserEmoteModel(CosmeticUser user) {
+    public UserEmoteModel(@NotNull CosmeticUser user) {
         super(user.getPlayer());
         this.user = user;
-        armorstandId = NMSHandlers.getHandler().getNextEntityId();
+        armorStandId = NMSHandlers.getHandler().getNextEntityId();
         getRangeManager().setRenderDistance(Settings.getViewDistance());
     }
 
     @Override
-    public void playAnimation(String id) {
+    public void playAnimation(@NotNull String id) {
         if (id.contains(":")) id = id.split(":", 2)[1];
         if (!id.contains(".")) id = id + "." + id + "." + id; // Make into a format that playerAnimator works with. Requires 3 splits.
         super.playAnimation(id);
@@ -63,12 +61,12 @@ public class UserEmoteModel extends PlayerModel {
 
         originalGamemode = player.getGameMode();
 
-        PacketManager.sendEntitySpawnPacket(thirdPersonLocation, armorstandId, EntityType.ARMOR_STAND, UUID.randomUUID(), viewer);
-        PacketManager.sendInvisibilityPacket(armorstandId, viewer);
-        PacketManager.sendLookPacket(armorstandId, player.getLocation(), viewer);
+        PacketManager.sendEntitySpawnPacket(thirdPersonLocation, armorStandId, EntityType.ARMOR_STAND, UUID.randomUUID(), viewer);
+        PacketManager.sendInvisibilityPacket(armorStandId, viewer);
+        PacketManager.sendLookPacket(armorStandId, player.getLocation(), viewer);
 
         PacketManager.gamemodeChangePacket(player, 3);
-        PacketManager.sendCameraPacket(armorstandId, viewer);
+        PacketManager.sendCameraPacket(armorStandId, viewer);
 
         MessagesUtil.sendDebugMessages("playAnimation run");
     }
@@ -99,7 +97,7 @@ public class UserEmoteModel extends PlayerModel {
 
             int entityId = player.getEntityId();
             PacketManager.sendCameraPacket(entityId, viewer);
-            PacketManager.sendEntityDestroyPacket(armorstandId, viewer);
+            PacketManager.sendEntityDestroyPacket(armorStandId, viewer);
             if (this.originalGamemode != null) {
                 PacketManager.gamemodeChangePacket(player, ServerUtils.convertGamemode(this.originalGamemode));
                 player.setGameMode(this.originalGamemode);
@@ -113,7 +111,6 @@ public class UserEmoteModel extends PlayerModel {
     }
 
     public boolean isPlayingAnimation() {
-        if (emotePlaying == null) return false;
-        return true;
+        return emotePlaying != null;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserWardrobeManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserWardrobeManager.java
@@ -114,8 +114,8 @@ public class UserWardrobeManager {
 
             // Misc
             if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
-                user.getUserBackpackManager().getArmorstand().teleport(npcLocation.clone().add(0, 2, 0));
-                PacketManager.ridingMountPacket(NPC_ID, user.getUserBackpackManager().getFirstArmorstandId(), viewer);
+                user.getUserBackpackManager().getArmorStand().teleport(npcLocation.clone().add(0, 2, 0));
+                PacketManager.ridingMountPacket(NPC_ID, user.getUserBackpackManager().getFirstArmorStandId(), viewer);
             }
 
             if (user.hasCosmeticInSlot(CosmeticSlot.BALLOON)) {
@@ -251,10 +251,10 @@ public class UserWardrobeManager {
                 }
 
                 if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
-                    PacketManager.sendTeleportPacket(user.getUserBackpackManager().getFirstArmorstandId(), location, false, viewer);
-                    PacketManager.ridingMountPacket(NPC_ID, user.getUserBackpackManager().getFirstArmorstandId(), viewer);
-                    user.getUserBackpackManager().getArmorstand().setRotation(nextyaw, 0);
-                    PacketManager.sendEntityDestroyPacket(user.getUserBackpackManager().getFirstArmorstandId(), outsideViewers);
+                    PacketManager.sendTeleportPacket(user.getUserBackpackManager().getFirstArmorStandId(), location, false, viewer);
+                    PacketManager.ridingMountPacket(NPC_ID, user.getUserBackpackManager().getFirstArmorStandId(), viewer);
+                    user.getUserBackpackManager().getArmorStand().setRotation(nextyaw, 0);
+                    PacketManager.sendEntityDestroyPacket(user.getUserBackpackManager().getFirstArmorStandId(), outsideViewers);
                 }
 
                 if (user.hasCosmeticInSlot(CosmeticSlot.BALLOON)) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/InventoryUtils.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/InventoryUtils.java
@@ -3,6 +3,8 @@ package com.hibiscusmc.hmccosmetics.util;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import org.bukkit.inventory.EquipmentSlot;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class InventoryUtils {
@@ -58,6 +60,8 @@ public class InventoryUtils {
         };
     }
 
+    @Contract(pure = true)
+    @Nullable
     public static CosmeticSlot BukkitCosmeticSlot(int slot) {
         switch (slot) {
             case 36 -> {
@@ -81,6 +85,8 @@ public class InventoryUtils {
         }
     }
 
+    @Contract(pure = true)
+    @Nullable
     public static CosmeticSlot NMSCosmeticSlot(int slot) {
         switch (slot) {
             case 5 -> {
@@ -104,7 +110,9 @@ public class InventoryUtils {
         }
     }
 
-    public static EquipmentSlot getEquipmentSlot(CosmeticSlot slot) {
+    @Contract(pure = true)
+    @Nullable
+    public static EquipmentSlot getEquipmentSlot(@NotNull CosmeticSlot slot) {
         switch (slot) {
             case HELMET -> {
                 return EquipmentSlot.HEAD;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/MessagesUtil.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/MessagesUtil.java
@@ -15,6 +15,8 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.title.Title;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 
 import java.time.Duration;
@@ -24,9 +26,9 @@ import java.util.logging.Level;
 public class MessagesUtil {
 
     private static String prefix;
-    private static HashMap<String, String> messages = new HashMap<>();
+    private static final HashMap<String, String> messages = new HashMap<>();
 
-    public static void setup(ConfigurationNode config) {
+    public static void setup(@NotNull ConfigurationNode config) {
         prefix = config.node("prefix").getString("");
         for (ConfigurationNode node : config.childrenMap().values()) {
             if (node.virtual()) continue;
@@ -35,7 +37,7 @@ public class MessagesUtil {
         }
      }
 
-    public static void sendMessage(CosmeticUser user, String key) {
+    public static void sendMessage(@NotNull CosmeticUser user, String key) {
         sendMessage(user.getPlayer(), key);
     }
 
@@ -92,6 +94,7 @@ public class MessagesUtil {
         return processString(player, key, null);
     }
 
+    @Nullable
     public static Component processString(Player player, String key, TagResolver placeholders) {
         if (!messages.containsKey(key)) return null;
         if (messages.get(key) == null) return null;
@@ -104,14 +107,17 @@ public class MessagesUtil {
         return Adventure.MINI_MESSAGE.deserialize(message);
     }
 
+    @NotNull
     public static Component processStringNoKey(String message) {
         return processStringNoKey(null, message, null);
     }
 
+    @NotNull
     public static Component processStringNoKey(Player player, String message) {
         return processStringNoKey(player, message, null);
     }
 
+    @NotNull
     public static Component processStringNoKey(Player player, String message, TagResolver placeholders) {
         message = message.replaceAll("%prefix%", prefix);
         if (Hooks.isActiveHook("PlaceholderAPI") && player != null) message = PlaceholderAPI.setPlaceholders(player, message);

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/PlayerUtils.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/PlayerUtils.java
@@ -6,12 +6,15 @@ import com.hibiscusmc.hmccosmetics.config.Settings;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PlayerUtils {
 
+    @Nullable
     public static WrappedSignedProperty getSkin(Player player) {
         WrappedSignedProperty skinData = WrappedGameProfile.fromPlayer(player).getProperties()
                 .get("textures").stream().findAny().orElse(null);
@@ -22,11 +25,13 @@ public class PlayerUtils {
         return new WrappedSignedProperty("textures", skinData.getValue(), skinData.getSignature());
     }
 
-    public static List<Player> getNearbyPlayers(Player player) {
+    @NotNull
+    public static List<Player> getNearbyPlayers(@NotNull Player player) {
         return getNearbyPlayers(player.getLocation());
     }
 
-    public static List<Player> getNearbyPlayers(Location location) {
+    @NotNull
+    public static List<Player> getNearbyPlayers(@NotNull Location location) {
         List<Player> players = new ArrayList<>();
         int viewDistance = Settings.getViewDistance();
         for (Entity entity : location.getWorld().getNearbyEntities(location, viewDistance, viewDistance, viewDistance)) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/builder/ColorBuilder.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/builder/ColorBuilder.java
@@ -6,6 +6,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.jetbrains.annotations.NotNull;
 
 public class ColorBuilder {
 
@@ -13,7 +14,7 @@ public class ColorBuilder {
         return canBeColored(new ItemStack(material));
     }
 
-    public static boolean canBeColored(final ItemStack itemStack) {
+    public static boolean canBeColored(final @NotNull ItemStack itemStack) {
         final ItemMeta itemMeta = itemStack.getItemMeta();
 
         return (itemMeta instanceof LeatherArmorMeta ||

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/builder/ItemBuilder.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/builder/ItemBuilder.java
@@ -8,6 +8,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +35,7 @@ public class ItemBuilder {
      * @param itemStack builder ItemStack
      */
 
-    ItemBuilder(final ItemStack itemStack) {
+    ItemBuilder(final @NotNull ItemStack itemStack) {
         this.material = itemStack.getType();
         this.itemMeta = itemStack.hasItemMeta() ? itemStack.getItemMeta()
                 : Bukkit.getItemFactory().getItemMeta(this.material);
@@ -44,6 +46,8 @@ public class ItemBuilder {
      * @return
      */
 
+    @Contract("_ -> new")
+    @NotNull
     public static ItemBuilder from(final Material material) {
         return new ItemBuilder(material);
     }
@@ -52,7 +56,8 @@ public class ItemBuilder {
      * @param itemStack builder ItemStack
      * @return
      */
-
+    @Contract("_ -> new")
+    @NotNull
     public static ItemBuilder from(final ItemStack itemStack) {
         return new ItemBuilder(itemStack);
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/misc/Keys.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/misc/Keys.java
@@ -6,6 +6,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public class Keys {
 
@@ -13,7 +14,7 @@ public class Keys {
     public static final NamespacedKey ITEM_KEY = new NamespacedKey(plugin, "cosmetic");
     public static final NamespacedKey TOKEN_KEY = new NamespacedKey(plugin, "token-key");
 
-    public static void setKey(final ItemStack itemStack) {
+    public static void setKey(final @NotNull ItemStack itemStack) {
         final ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (itemMeta == null) {
@@ -26,7 +27,7 @@ public class Keys {
     }
 
     public static <T, Z> void setKey(
-            final ItemStack itemStack,
+            final @NotNull ItemStack itemStack,
             final NamespacedKey key,
             final PersistentDataType<T, Z> type,
             final Z value) {
@@ -41,7 +42,7 @@ public class Keys {
         itemStack.setItemMeta(itemMeta);
     }
 
-    public static boolean hasKey(final ItemStack itemStack) {
+    public static boolean hasKey(final @NotNull ItemStack itemStack) {
         final ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (itemMeta == null) {
@@ -51,7 +52,7 @@ public class Keys {
         return itemMeta.getPersistentDataContainer().has(ITEM_KEY, PersistentDataType.BYTE);
     }
 
-    public static <T, Z> boolean hasKey(final ItemStack itemStack, final NamespacedKey key, final PersistentDataType<T, Z> type) {
+    public static <T, Z> boolean hasKey(final @NotNull ItemStack itemStack, final NamespacedKey key, final PersistentDataType<T, Z> type) {
         final ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (itemMeta == null) {
@@ -62,7 +63,7 @@ public class Keys {
     }
 
     @Nullable
-    public static <T, Z> Z getValue(final ItemStack itemStack, final NamespacedKey key, final PersistentDataType<T, Z> type) {
+    public static <T, Z> Z getValue(final @NotNull ItemStack itemStack, final NamespacedKey key, final PersistentDataType<T, Z> type) {
         final ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (itemMeta == null) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/misc/StringUtils.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/misc/StringUtils.java
@@ -1,6 +1,7 @@
 package com.hibiscusmc.hmccosmetics.util.misc;
 
 import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
 
 public class StringUtils {
 
@@ -8,15 +9,17 @@ public class StringUtils {
      * @param parsed message to be parsed
      * @return MiniMessage parsed string
      */
-
+    @NotNull
     public static Component parse(final String parsed) {
         return Adventure.MINI_MESSAGE.deserialize(parsed);
     }
 
+    @NotNull
     public static String parseStringToString(final String parsed) {
         return Adventure.SERIALIZER.serialize(Adventure.MINI_MESSAGE.deserialize(parsed));
     }
 
+    @NotNull
     public static String formatArmorItemType(String type) {
         type = type.toLowerCase();
         final String[] parts = type.split(" ");

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/misc/Utils.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/misc/Utils.java
@@ -29,7 +29,7 @@ public class Utils {
         return original;
     }
 
-    public static <T> T replaceIf(final @Nullable T original, final T replacement, final Predicate<T> predicate) {
+    public static <T> T replaceIf(final @Nullable T original, final T replacement, final @NotNull Predicate<T> predicate) {
         if (predicate.test(original)) return replacement;
         return original;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/PacketManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/PacketManager.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,11 +32,11 @@ import java.util.UUID;
 public class PacketManager extends BasePacket {
 
     public static void sendEntitySpawnPacket(
-            final Location location,
+            final @NotNull Location location,
             final int entityId,
             final EntityType entityType,
             final UUID uuid,
-            final List<Player> sendTo
+            final @NotNull List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.SPAWN_ENTITY);
         packet.getModifier().writeDefaults();
@@ -64,7 +65,7 @@ public class PacketManager extends BasePacket {
     public static void ridingMountPacket(
             int mountId,
             int passengerId,
-            List<Player> sendTo
+            @NotNull List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.MOUNT);
         packet.getIntegers().write(0, mountId);
@@ -84,7 +85,7 @@ public class PacketManager extends BasePacket {
         }
     }
     public static void equipmentSlotUpdate(
-            Player player,
+            @NotNull Player player,
             CosmeticSlot cosmetic,
             List<Player> sendTo
     ) {
@@ -111,7 +112,7 @@ public class PacketManager extends BasePacket {
     }
 
     public static void armorStandMetaPacket(
-            Entity entity,
+            @NotNull Entity entity,
             List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.ENTITY_METADATA);
@@ -147,9 +148,9 @@ public class PacketManager extends BasePacket {
     }
 
     public static void sendLookPacket(
-             int entityId,
-             Location location,
-             List<Player> sendTo
+            int entityId,
+            @NotNull Location location,
+            @NotNull List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.ENTITY_HEAD_ROTATION);
         packet.getIntegers().write(0, entityId);
@@ -166,10 +167,10 @@ public class PacketManager extends BasePacket {
     }
 
     public static void sendRotationPacket(
-             int entityId,
-             Location location,
-             boolean onGround,
-             List<Player> sendTo
+            int entityId,
+            @NotNull Location location,
+            boolean onGround,
+            @NotNull List<Player> sendTo
     ) {
         float ROTATION_FACTOR = 256.0F / 360.0F;
         float yaw = location.getYaw() * ROTATION_FACTOR;
@@ -188,7 +189,7 @@ public class PacketManager extends BasePacket {
             int entityId,
             int yaw,
             boolean onGround,
-            List<Player> sendTo
+            @NotNull List<Player> sendTo
     ) {
         float ROTATION_FACTOR = 256.0F / 360.0F;
         float yaw2 = yaw * ROTATION_FACTOR;
@@ -225,7 +226,7 @@ public class PacketManager extends BasePacket {
     public static void sendRidingPacket(
             final int mountId,
             final int passengerId,
-            final List<Player> sendTo
+            final @NotNull List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.MOUNT);
         packet.getIntegers().write(0, mountId);
@@ -240,7 +241,7 @@ public class PacketManager extends BasePacket {
      * @param entityId The entity to delete for a player
      * @param sendTo The players the packet should be sent to
      */
-    public static void sendEntityDestroyPacket(final int entityId, List<Player> sendTo) {
+    public static void sendEntityDestroyPacket(final int entityId, @NotNull List<Player> sendTo) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.ENTITY_DESTROY);
         packet.getModifier().write(0, new IntArrayList(new int[]{entityId}));
         for (final Player p : sendTo) sendPacket(p, packet);
@@ -251,7 +252,7 @@ public class PacketManager extends BasePacket {
      * @param entityId The Entity ID that camera will go towards
      * @param sendTo The players that will be sent this packet
      */
-    public static void sendCameraPacket(final int entityId, List<Player> sendTo) {
+    public static void sendCameraPacket(final int entityId, @NotNull List<Player> sendTo) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.CAMERA);
         packet.getIntegers().write(0, entityId);
         for (final Player p : sendTo) sendPacket(p, packet);
@@ -266,10 +267,10 @@ public class PacketManager extends BasePacket {
      * @param sendTo Who should it send the packet to?
      */
     public static void sendFakePlayerSpawnPacket(
-            final Location location,
+            final @NotNull Location location,
             final UUID uuid,
             final int entityId,
-            final List<Player> sendTo
+            final @NotNull List<Player> sendTo
     ) {
         WrapperPlayServerNamedEntitySpawn wrapper = new WrapperPlayServerNamedEntitySpawn();
         wrapper.setEntityID(entityId);
@@ -326,7 +327,7 @@ public class PacketManager extends BasePacket {
      */
     public static void sendPlayerOverlayPacket(
             final int playerId,
-            final List<Player> sendTo
+            final @NotNull List<Player> sendTo
     ) {
         /*
         0x01 = Is on fire
@@ -398,7 +399,7 @@ public class PacketManager extends BasePacket {
     public static void sendLeashPacket(
             final int leashedEntity,
             final int entityId,
-            final List<Player> sendTo
+            final @NotNull List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.ATTACH_ENTITY);
         packet.getIntegers().write(0, leashedEntity);
@@ -417,9 +418,9 @@ public class PacketManager extends BasePacket {
      */
     public static void sendTeleportPacket(
             final int entityId,
-            final Location location,
+            final @NotNull Location location,
             boolean onGround,
-            final List<Player> sendTo
+            final @NotNull List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.ENTITY_TELEPORT);
         packet.getIntegers().write(0, entityId);
@@ -444,10 +445,10 @@ public class PacketManager extends BasePacket {
      */
     public static void sendMovePacket(
             final int entityId,
-            final Location from,
-            final Location to,
+            final @NotNull Location from,
+            final @NotNull Location to,
             final boolean onGround,
-            List<Player> sendTo
+            @NotNull List<Player> sendTo
     ) {
         PacketContainer packet = new PacketContainer(PacketType.Play.Server.REL_ENTITY_MOVE);
         WrapperPlayServerRelEntityMove wrapper = new WrapperPlayServerRelEntityMove(packet);
@@ -470,6 +471,7 @@ public class PacketManager extends BasePacket {
         sendMovePacket(entityId, from, to, onGround, getViewers(to));
     }
 
+    @NotNull
     public static List<Player> getViewers(Location location) {
         ArrayList<Player> viewers = new ArrayList();
         if (Settings.getViewDistance() <= 0) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/wrappers/WrapperPlayServerNamedEntitySpawn.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/wrappers/WrapperPlayServerNamedEntitySpawn.java
@@ -6,6 +6,7 @@ import com.comphenix.protocol.events.PacketEvent;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
@@ -58,7 +59,7 @@ public class WrapperPlayServerNamedEntitySpawn extends AbstractPacket {
      * @param event - the packet event.
      * @return The spawned entity.
      */
-    public Entity getEntity(PacketEvent event) {
+    public Entity getEntity(@NotNull PacketEvent event) {
         return getEntity(event.getPlayer().getWorld());
     }
 
@@ -96,7 +97,7 @@ public class WrapperPlayServerNamedEntitySpawn extends AbstractPacket {
      *
      * @param position - the new position.
      */
-    public void setPosition(Vector position) {
+    public void setPosition(@NotNull Vector position) {
         setX(position.getX());
         setY(position.getY());
         setZ(position.getZ());

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/wrappers/WrapperPlayServerRelEntityMove.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/wrappers/WrapperPlayServerRelEntityMove.java
@@ -5,6 +5,7 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 
 public class WrapperPlayServerRelEntityMove extends AbstractPacket {
     public static final PacketType TYPE =
@@ -55,7 +56,7 @@ public class WrapperPlayServerRelEntityMove extends AbstractPacket {
      * @param event - the packet event.
      * @return The spawned entity.
      */
-    public Entity getEntity(PacketEvent event) {
+    public Entity getEntity(@NotNull PacketEvent event) {
         return getEntity(event.getPlayer().getWorld());
     }
 


### PR DESCRIPTION
This PR fixes several issues:

- Adds annotations to most methods lacking them for consistency.
- Declares unmodified class properties as final, for consistency and so safety.
- Removed unused imports.

Minor spelling mistakes were fixed, such as:
- `steralizeData` -> `serializeData`
- `armorstand` -> `armorStand` (*made this change since armor stand are two separate words, trying to stay consistent*)

Minor code changes were made as well, such as:

- [`CosmeticCommand.java`](https://github.com/HibiscusMC/HMCCosmetics/commit/601d6f8a53fb8ef736df60e7f916977466edb9f5?diff=split#diff-0849ade64abda32f7d90851c8e5e97ef32252f186dc99e6a9c87f877f147dc42) Breaking out of the for-loop once the `-s` flag is found anywhere in the command arguments.
```java
// Old
for (String singleArg : args) {
    if (singleArg.equalsIgnoreCase("-s")) silent = true;    
}

// New
for (String singleArg : args) {
    if (singleArg.equalsIgnoreCase("-s")) {
        silent = true;
        break;
    }   
}
```

- [`CosmeticCommand.java`](https://github.com/HibiscusMC/HMCCosmetics/commit/601d6f8a53fb8ef736df60e7f916977466edb9f5?diff=split#diff-0849ade64abda32f7d90851c8e5e97ef32252f186dc99e6a9c87f877f147dc42) Removing unnecessary assignment to null when variable is initialized. 
```java
// Old
CosmeticSlot cosmeticSlot = null;

// New
CosmeticSlot cosmeticSlot;
```

- [`Cosmetic.java`](https://github.com/Craftinators/HMCCosmetics/commit/d508ecd4c04724088e7c1f53dfbfdfcc5f92c3e3#diff-5a08552091085afe8aa23c80f7da8d96a399499fd9ce9be02b69dfdb40671c40) Simplifying if statement by removing redundant code.
```java
// Old
public boolean requiresPermission() {
    if (permission == null) return false;
    return true;
}

// New
public boolean requiresPermission() {
    return permission != null
}
```

- [`Type.java`](https://github.com/Craftinators/HMCCosmetics/commit/d508ecd4c04724088e7c1f53dfbfdfcc5f92c3e3#diff-714293711f98520902bde29aab60c13fcb1b82e7c71a25b607b29aff13cf4dcb) Moved declaration of `newLocation` down before the initial null checks so `player` must defined by the time `newLocation` is declared, preventing `newLocation` from producing a null pointer exception (*i.e. If `player` **IS** null, then `newLocation` would never be declared*).
```java
// Old
@Override
public void update(CosmeticUser user) {
    Player player = Bukkit.getPlayer(user.getUniqueId());
    UserBalloonManager userBalloonManager = user.getBalloonManager();
    Location newLocation = player.getLocation();
    if (player == null || userBalloonManager == null || newLocation == null) return;
    if (user.isInWardrobe()) return;
    Location currentLocation = user.getBalloonManager().getLocation();
    newLocation = newLocation.clone().add(Settings.getBalloonOffset());
    // ...
}

// New
@Override
public void update(@NotNull CosmeticUser user) {
    Player player = Bukkit.getPlayer(user.getUniqueId());
    UserBalloonManager userBalloonManager = user.getBalloonManager();

    if (player == null || userBalloonManager == null) return;
    if (user.isInWardrobe()) return;

    Location newLocation = player.getLocation();
    Location currentLocation = user.getBalloonManager().getLocation();
    newLocation = newLocation.clone().add(Settings.getBalloonOffset());
    // ...
}
```

And various other small changes