### PR TITLE
clean: use preferred method

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteModel.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteModel.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -35,13 +36,16 @@ public class UserEmoteModel extends PlayerModel {
 
     @Override
     public void playAnimation(@NotNull String id) {
-        if (id.contains(":")) id = id.split(":", 2)[1];
+        if (id.contains(":")) id = id.split(":", 2)[1]; // A:B -> B -> B.B.B
         if (!id.contains(".")) id = id + "." + id + "." + id; // Make into a format that playerAnimator works with. Requires 3 splits.
+
         super.playAnimation(id);
+
         emotePlaying = id;
+
         // Add config option that either allows player to move or forces them into a spot.
         Player player = user.getPlayer();
-        List<Player> viewer = List.of(user.getPlayer());
+        List<Player> viewer = Collections.singletonList(user.getPlayer());
         List<Player> outsideViewers = PacketManager.getViewers(player.getLocation());
         outsideViewers.remove(player);
 
@@ -49,13 +53,16 @@ public class UserEmoteModel extends PlayerModel {
 
         Location newLocation = player.getLocation().clone();
         newLocation.setPitch(0);
+
         double DISTANCE = Settings.getEmoteDistance();
+
         Location thirdPersonLocation = newLocation.add(newLocation.getDirection().normalize().multiply(DISTANCE));
         if (thirdPersonLocation.getBlock().getType() != Material.AIR) {
             stopAnimation();
             MessagesUtil.sendMessage(player, "emote-blocked");
             return;
         }
+
         user.getPlayer().setInvisible(true);
         user.hideCosmetics(CosmeticUser.HiddenReason.EMOTE);
 
@@ -88,10 +95,10 @@ public class UserEmoteModel extends PlayerModel {
         emotePlaying = null;
         despawn();
         Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
-            if (user.getPlayer() == null) return;
             Player player = user.getPlayer();
-            List<Player> viewer = List.of(user.getPlayer());
-            if (viewer == null) return;
+            if (player == null) return;
+
+            List<Player> viewer = Collections.singletonList(player);
             List<Player> outsideViewers = PacketManager.getViewers(player.getLocation());
             outsideViewers.remove(player);
 


### PR DESCRIPTION
This PR provides a single minor change:

[`UserEmoteModel.java`](https://github.com/Craftinators/HMCCosmetics/commit/147be9ab7c0656eba6382db55540bc9d9475cad7#diff-ed27a6e562f10ec51d786ae6a1469458fa49c8fc060c3bc8975ae4c9d95835da) Switches the use of `List.of()` for the preferred method of `Collections.singletonList()` since `viewer` is a single element immutable iterable.
```java
// Old
List<Player> viewer = List.of(player);
// New
List<Player> viewer = Collections.singletonList(player);
```

