### PR TITLE
Database structure changes

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/Data.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/Data.java
@@ -17,27 +17,20 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class Data {
+public abstract class Data {
 
-    public void setup() {
-        // Override
-    }
+    public abstract void setup();
 
-    public void save(CosmeticUser user) {
-        // Override
-    }
+    public abstract void save(CosmeticUser user);
 
     @Nullable
-    public CosmeticUser get(UUID uniqueId) {
-        // Override
-        return null;
-    }
+    public abstract CosmeticUser get(UUID uniqueId);
 
-    public void clear(UUID uniqueId) {
-        // Override
-    }
+    public abstract void clear(UUID uniqueId);
+
     // BACKPACK=colorfulbackpack&RRGGBB,HELMET=niftyhat,BALLOON=colorfulballoon,CHESTPLATE=niftychestplate
-    public String serializeData(@NotNull CosmeticUser user) {
+    @NotNull
+    public final String serializeData(@NotNull CosmeticUser user) {
         String data = "";
         if (user.getHidden()) {
             if (shouldHiddenSave(user.getHiddenReason())) {
@@ -57,7 +50,8 @@ public class Data {
         return data;
     }
 
-    public Map<CosmeticSlot, Map<Cosmetic, Color>> deserializeData(CosmeticUser user, @NotNull String raw) {
+    @NotNull
+    public final Map<CosmeticSlot, Map<Cosmetic, Color>> deserializeData(CosmeticUser user, @NotNull String raw) {
         Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = new HashMap<>();
         boolean checkPermission = Settings.getForcePermissionJoin();
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -79,10 +79,12 @@ public class MySQLData extends SQLData {
 
         // Connect to database host
         try {
-            // Class.forName("com.mysql.jdbc.Driver");
+            Class.forName("com.mysql.jdbc.Driver");
             connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database, setupProperties());
         } catch (SQLException e) {
             System.out.println(e.getMessage());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -56,8 +56,7 @@ public class MySQLData extends Data {
     @Override
     public void save(CosmeticUser user) {
         Runnable run = () -> {
-            try {
-                PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);");
+            try (PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);")) {
                 preparedSt.setString(1, user.getUniqueId().toString());
                 preparedSt.setString(2, serializeData(user));
                 preparedSt.executeUpdate();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -63,8 +63,6 @@ public class MySQLData extends SQLData {
                 e.printStackTrace();
             }
         });
-
-        // TODO (Something)
     }
 
     private void openConnection() throws SQLException {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -33,11 +33,12 @@ public class MySQLData extends SQLData {
         HMCCosmeticsPlugin plugin = HMCCosmeticsPlugin.getInstance();
         try {
             openConnection();
+            if (connection == null) throw new NullPointerException("Connection is null");
             connection.prepareStatement("CREATE TABLE IF NOT EXISTS `COSMETICDATABASE` " +
                     "(UUID varchar(36) PRIMARY KEY, " +
                     "COSMETICS MEDIUMTEXT " +
                     ");").execute();
-        } catch (SQLException e) {
+        } catch (SQLException | NullPointerException e) {
             plugin.getLogger().severe("");
             plugin.getLogger().severe("");
             plugin.getLogger().severe("MySQL DATABASE CAN NOT BE REACHED.");
@@ -94,7 +95,7 @@ public class MySQLData extends SQLData {
     public void close() {
         Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
             try {
-                if (connection == null) throw new NullPointerException();
+                if (connection == null) throw new NullPointerException("Connection is null");
                 connection.close();
             } catch (SQLException | NullPointerException e) {
                 System.out.println(e.getMessage());
@@ -128,7 +129,7 @@ public class MySQLData extends SQLData {
         }
 
         try {
-            if (connection == null) throw new NullPointerException();
+            if (connection == null) throw new NullPointerException("Connection is null");
             ps = connection.prepareStatement(query);
         } catch (SQLException | NullPointerException e) {
             e.printStackTrace();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -55,7 +55,8 @@ public class MySQLData extends SQLData {
     @Override
     public void clear(UUID uniqueId) {
         Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
-            try (PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;")) {
+            try {
+                PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;");
                 preparedSt.setString(1, uniqueId.toString());
                 preparedSt.executeUpdate();
             } catch (SQLException e) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -2,19 +2,14 @@ package com.hibiscusmc.hmccosmetics.database.types;
 
 import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.config.DatabaseSettings;
-import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
-import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
-import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.Bukkit;
-import org.bukkit.Color;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.*;
-import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
-public class MySQLData extends Data {
+public class MySQLData extends SQLData {
 
     // Connection Information
     private String host;
@@ -53,51 +48,6 @@ public class MySQLData extends Data {
             throw new RuntimeException(e);
         }
     }
-    @Override
-    public void save(CosmeticUser user) {
-        Runnable run = () -> {
-            try (PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);")) {
-                preparedSt.setString(1, user.getUniqueId().toString());
-                preparedSt.setString(2, serializeData(user));
-                preparedSt.executeUpdate();
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
-        };
-        if (!HMCCosmeticsPlugin.isDisable()) {
-            Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), run);
-        } else {
-            run.run();
-        }
-    }
-
-    @Override
-    public CosmeticUser get(UUID uniqueId) {
-        CosmeticUser user = new CosmeticUser(uniqueId);
-
-        Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
-            try {
-                PreparedStatement preparedStatement = preparedStatement("SELECT * FROM COSMETICDATABASE WHERE UUID = ?;");
-                preparedStatement.setString(1, uniqueId.toString());
-                ResultSet rs = preparedStatement.executeQuery();
-                if (rs.next()) {
-                    String rawData = rs.getString("COSMETICS");
-                    Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = deserializeData(user, rawData);
-                    for (Map<Cosmetic, Color> cosmeticColors : cosmetics.values()) {
-                        for (Cosmetic cosmetic : cosmeticColors.keySet()) {
-                            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
-                                // This can not be async.
-                                user.addPlayerCosmetic(cosmetic, cosmeticColors.get(cosmetic));
-                            });
-                        }
-                    }
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
-        });
-        return user;
-    }
 
     @Override
     public void clear(UUID uniqueId) {
@@ -110,7 +60,8 @@ public class MySQLData extends Data {
                 e.printStackTrace();
             }
         });
-        // TODO
+
+        // TODO (Something)
     }
 
     private void openConnection() throws SQLException {
@@ -162,6 +113,7 @@ public class MySQLData extends Data {
         }
     }
 
+    @Override
     public PreparedStatement preparedStatement(String query) {
         PreparedStatement ps = null;
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -4,6 +4,7 @@ import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.config.DatabaseSettings;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.sql.*;
 import java.util.Properties;
@@ -18,6 +19,7 @@ public class MySQLData extends SQLData {
     private String password;
     private int port;
 
+    @Nullable
     private Connection connection;
 
     @Override
@@ -73,7 +75,7 @@ public class MySQLData extends SQLData {
         try {
             if (isConnectionOpen()) {
                 return;
-            } else close(); // Close connection if still active
+            } else if (connection != null) close(); // Close connection if still active
         } catch (RuntimeException e) {
             e.printStackTrace(); // If isConnectionOpen() throws error
         }
@@ -92,8 +94,9 @@ public class MySQLData extends SQLData {
     public void close() {
         Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
             try {
+                if (connection == null) throw new NullPointerException();
                 connection.close();
-            } catch (SQLException e) {
+            } catch (SQLException | NullPointerException e) {
                 System.out.println(e.getMessage());
             }
         });
@@ -125,8 +128,9 @@ public class MySQLData extends SQLData {
         }
 
         try {
+            if (connection == null) throw new NullPointerException();
             ps = connection.prepareStatement(query);
-        } catch (SQLException e) {
+        } catch (SQLException | NullPointerException e) {
             e.printStackTrace();
         }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -7,6 +7,7 @@ import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
+import org.jetbrains.annotations.NotNull;
 
 import java.sql.*;
 import java.util.Map;
@@ -100,11 +101,11 @@ public class MySQLData extends Data {
     }
 
     @Override
-    public void clear(UUID unqiueId) {
+    public void clear(UUID uniqueId) {
         Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
             try {
                 PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;");
-                preparedSt.setString(1, unqiueId.toString());
+                preparedSt.setString(1, uniqueId.toString());
                 preparedSt.executeUpdate();
             } catch (SQLException e) {
                 e.printStackTrace();
@@ -114,30 +115,25 @@ public class MySQLData extends Data {
     }
 
     private void openConnection() throws SQLException {
-        if (connection != null && !connection.isClosed()) {
-            return;
+        // Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
+        // ...
+        // });
+        // connection = DriverManager.getConnection("jdbc:mysql://" + DatabaseSettings.getHost() + ":" + DatabaseSettings.getPort() + "/" + DatabaseSettings.getDatabase(), setupProperties());
+
+        if (connection != null && !connection.isClosed()) return;
+
+        // Close connection if still active
+        if (connection != null) {
+            close();
         }
-        //Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
 
-            //close Connection if still active
-            if (connection != null) {
-                close();
-            }
-
-            //connect to database host
-            try {
-                Class.forName("com.mysql.jdbc.Driver");
-
-                connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database, setupProperties());
-
-            } catch (SQLException e) {
-                System.out.println(e.getMessage());
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-
-        //});
-        //connection = DriverManager.getConnection("jdbc:mysql://" + DatabaseSettings.getHost() + ":" + DatabaseSettings.getPort() + "/" + DatabaseSettings.getDatabase(), setupProperties());
+        // Connect to database host
+        try {
+            // Class.forName("com.mysql.jdbc.Driver");
+            connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database, setupProperties());
+        } catch (SQLException e) {
+            System.out.println(e.getMessage());
+        }
     }
 
     public void close() {
@@ -150,6 +146,7 @@ public class MySQLData extends Data {
         });
     }
 
+    @NotNull
     private Properties setupProperties() {
         Properties props = new Properties();
         props.put("user", user);
@@ -168,14 +165,17 @@ public class MySQLData extends Data {
 
     public PreparedStatement preparedStatement(String query) {
         PreparedStatement ps = null;
+
         if (!isConnectionOpen()) {
             HMCCosmeticsPlugin.getInstance().getLogger().info("Connection is not open");
         }
+
         try {
             ps = connection.prepareStatement(query);
         } catch (SQLException e) {
             e.printStackTrace();
         }
+
         return ps;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLData.java
@@ -1,0 +1,65 @@
+package com.hibiscusmc.hmccosmetics.database.types;
+
+import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
+import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
+import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
+import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.UUID;
+
+public abstract class SQLData extends Data {
+    @Override
+    @SuppressWarnings("Duplicates") // Duplicate is from deprecated InternalData
+    public CosmeticUser get(UUID uniqueId) {
+        CosmeticUser user = new CosmeticUser(uniqueId);
+
+        Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
+            try (PreparedStatement preparedStatement = preparedStatement("SELECT * FROM COSMETICDATABASE WHERE UUID = ?;")) {
+                preparedStatement.setString(1, uniqueId.toString());
+                ResultSet rs = preparedStatement.executeQuery();
+                if (rs.next()) {
+                    String rawData = rs.getString("COSMETICS");
+                    Map<CosmeticSlot, Map<Cosmetic, Color>> cosmetics = deserializeData(user, rawData);
+                    for (Map<Cosmetic, Color> cosmeticColors : cosmetics.values()) {
+                        for (Cosmetic cosmetic : cosmeticColors.keySet()) {
+                            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
+                                // This can not be async.
+                                user.addPlayerCosmetic(cosmetic, cosmeticColors.get(cosmetic));
+                            });
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        });
+
+        return user;
+    }
+
+    @Override
+    public void save(CosmeticUser user) {
+        Runnable run = () -> {
+            try (PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);")) {
+                preparedSt.setString(1, user.getUniqueId().toString());
+                preparedSt.setString(2, serializeData(user));
+                preparedSt.executeUpdate();
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        };
+        if (!HMCCosmeticsPlugin.isDisable()) {
+            Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), run);
+        } else {
+            run.run();
+        }
+    }
+
+    public abstract PreparedStatement preparedStatement(String query);
+}

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLData.java
@@ -15,12 +15,13 @@ import java.util.UUID;
 
 public abstract class SQLData extends Data {
     @Override
-    @SuppressWarnings("Duplicates") // Duplicate is from deprecated InternalData
+    @SuppressWarnings({"Duplicates", "resource"}) // Duplicate is from deprecated InternalData
     public CosmeticUser get(UUID uniqueId) {
         CosmeticUser user = new CosmeticUser(uniqueId);
 
         Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
-            try (PreparedStatement preparedStatement = preparedStatement("SELECT * FROM COSMETICDATABASE WHERE UUID = ?;")) {
+            try {
+                PreparedStatement preparedStatement = preparedStatement("SELECT * FROM COSMETICDATABASE WHERE UUID = ?;");
                 preparedStatement.setString(1, uniqueId.toString());
                 ResultSet rs = preparedStatement.executeQuery();
                 if (rs.next()) {
@@ -44,9 +45,11 @@ public abstract class SQLData extends Data {
     }
 
     @Override
+    @SuppressWarnings("resource")
     public void save(CosmeticUser user) {
         Runnable run = () -> {
-            try (PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);")) {
+            try {
+                PreparedStatement preparedSt = preparedStatement("REPLACE INTO COSMETICDATABASE(UUID,COSMETICS) VALUES(?,?);");
                 preparedSt.setString(1, user.getUniqueId().toString());
                 preparedSt.setString(2, serializeData(user));
                 preparedSt.executeUpdate();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
@@ -107,29 +107,23 @@ public class SQLiteData extends Data {
 
 
     private void openConnection() throws SQLException {
-        if (connection != null && !connection.isClosed()) {
-            return;
-        }
-        //Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
+        // Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
+        // ...
+        // });
+        // connection = DriverManager.getConnection("jdbc:mysql://" + DatabaseSettings.getHost() + ":" + DatabaseSettings.getPort() + "/" + DatabaseSettings.getDatabase(), setupProperties());
 
-        //close Connection if still active
+        if (connection != null && !connection.isClosed()) return;
 
+        // Close Connection if still active
         File dataFolder = new File(HMCCosmeticsPlugin.getInstance().getDataFolder(), "database.db");
 
-        //connect to database host
+        // Connect to database host
         try {
-            Class.forName("org.sqlite.JDBC");
-
+            // Class.forName("org.sqlite.JDBC");
             connection = DriverManager.getConnection("jdbc:sqlite:" + dataFolder);
-
         } catch (SQLException e) {
             System.out.println(e.getMessage());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
         }
-
-        //});
-        //connection = DriverManager.getConnection("jdbc:mysql://" + DatabaseSettings.getHost() + ":" + DatabaseSettings.getPort() + "/" + DatabaseSettings.getDatabase(), setupProperties());
     }
 
     public PreparedStatement preparedStatement(String query) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
@@ -42,9 +42,11 @@ public class SQLiteData extends SQLData {
     }
 
     @Override
+    @SuppressWarnings("resource")
     public void clear(UUID uniqueId) {
         Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
-            try (PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;")) {
+            try {
+                PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;");
                 preparedSt.setString(1, uniqueId.toString());
                 preparedSt.executeUpdate();
             } catch (SQLException e) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
@@ -94,11 +94,10 @@ public class SQLiteData extends Data {
     }
 
     @Override
-    public void clear(UUID unqiueId) {
+    public void clear(UUID uniqueId) {
         Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
-            try {
-                PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;");
-                preparedSt.setString(1, unqiueId.toString());
+            try (PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;")) {
+                preparedSt.setString(1, uniqueId.toString());
                 preparedSt.executeUpdate();
             } catch (SQLException e) {
                 e.printStackTrace();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
@@ -66,10 +66,12 @@ public class SQLiteData extends SQLData {
 
         // Connect to database host
         try {
-            // Class.forName("org.sqlite.JDBC");
+            Class.forName("org.sqlite.JDBC");
             connection = DriverManager.getConnection("jdbc:sqlite:" + dataFolder);
         } catch (SQLException e) {
             System.out.println(e.getMessage());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLiteData.java
@@ -17,10 +17,12 @@ public class SQLiteData extends SQLData {
     @Override
     public void setup() {
         File dataFolder = new File(HMCCosmeticsPlugin.getInstance().getDataFolder(), "database.db");
+        boolean exists = dataFolder.exists();
 
-        if (!dataFolder.exists()){
+        if (!exists) {
             try {
-                dataFolder.createNewFile();
+                boolean created = dataFolder.createNewFile();
+                if (!created) throw new IOException("File didn't exist but now does");
             } catch (IOException e) {
                 MessagesUtil.sendDebugMessages("File write error. Database will not work properly", Level.SEVERE);
             }


### PR DESCRIPTION
This PR fixes several issues:

- Adds annotations to most methods lacking them for consistency.
- Made [`Data`](https://github.com/Craftinators/HMCCosmetics/blob/remapped/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/Data.java) abstract to more accurately reflect its purpose.
- Introduced [`SQLData`](https://github.com/Craftinators/HMCCosmetics/blob/remapped/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/SQLData.java), another abstract class to host similar methods that both `MySQLData` and `SQLiteData` share in common

Minor spelling mistakes were fixed:
- `unqiueId` -> `uniqueId`

Minor code changes were made as well, such as:
- Changed `try` statements to `try-with-resources` statements:
```java
// Old
try {
    PreparedStatement preparedSt = preparedStatement(...);
    // ...
}

// New
try (PreparedStatement preparedSt = preparedStatement(...)) {
    // ...
}
```

- [`SQLiteData.setup()`](https://github.com/Craftinators/HMCCosmetics/commit/ef4d53eb85a3ae07e72590615c22544c083f93ad#diff-36b346a8c4216dcc8615cddb77e6e8fdfb00eef814f6997670e92a35d3356715) now throws an error if the file `database.db` doesn't exist before attempting to create it *(Point A)*, but somehow exists during creation *(Point B)*. This error should never happen, but can may happen if another program creates a `database.db` file during that small window
```java
// Old
if (!dataFolder.exists()){
    try {
        dataFolder.createNewFile();
    }
    // ...
}

// New
// Point A
if (!exists) {
    try {
        // Point B
        boolean created = dataFolder.createNewFile();
        if (!created) throw new IOException("File didn't exist but now does");
    }
    // ...
}
```

And various other small changes