### PR TITLE
`CosmeticType` Abstraction

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetic.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetic.java
@@ -12,7 +12,7 @@ import org.spongepowered.configurate.serialize.SerializationException;
 
 import java.util.logging.Level;
 
-public class Cosmetic {
+public abstract class Cosmetic {
 
     private String id;
     private String permission;
@@ -22,6 +22,7 @@ public class Cosmetic {
 
     protected Cosmetic(String id, @NotNull ConfigurationNode config) {
         this.id = id;
+
         if (!config.node("permission").virtual()) {
             this.permission = config.node("permission").getString();
         } else {
@@ -31,20 +32,20 @@ public class Cosmetic {
         if (!config.node("item").virtual()) this.item = generateItemStack(config.node("item"));
 
         MessagesUtil.sendDebugMessages("Slot: " + config.node("slot").getString());
-        setSlot(CosmeticSlot.valueOf(config.node("slot").getString()));
 
+        setSlot(CosmeticSlot.valueOf(config.node("slot").getString()));
         setDyable(config.node("dyeable").getBoolean(false));
 
         MessagesUtil.sendDebugMessages("Dyeable " + dyable);
-
         Cosmetics.addCosmetic(this);
     }
 
     public String getId() {
         return this.id;
     }
-    public String getPermission() {
-        return this.permission;
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     public CosmeticSlot getSlot() {
@@ -54,16 +55,17 @@ public class Cosmetic {
     public void setSlot(CosmeticSlot slot) {
         this.slot = slot;
     }
+
+    public String getPermission() {
+        return this.permission;
+    }
+
     public void setPermission(String permission) {
         this.permission = permission;
     }
 
     public boolean requiresPermission() {
         return permission != null;
-    }
-
-    public void setId(String id) {
-        this.id = id;
     }
 
     public void setDyable(boolean dyable) {
@@ -74,10 +76,7 @@ public class Cosmetic {
         return this.dyable;
     }
 
-
-    public void update(CosmeticUser user) {
-        // Override
-    }
+    public abstract void update(CosmeticUser user);
 
     @Nullable
     public ItemStack getItem() {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticArmorType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticArmorType.java
@@ -33,6 +33,4 @@ public class CosmeticArmorType extends Cosmetic {
     public EquipmentSlot getEquipSlot() {
         return this.equipSlot;
     }
-
-
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBackpackType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBackpackType.java
@@ -12,12 +12,10 @@ import org.spongepowered.configurate.ConfigurationNode;
 public class CosmeticBackpackType extends Cosmetic {
 
     private final String modelName;
-    private ConfigurationNode config;
 
     public CosmeticBackpackType(String id, ConfigurationNode config) {
         super(id, config);
 
-        this.config = config;
         modelName = config.node("model").getString();
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBalloonType.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/types/CosmeticBalloonType.java
@@ -19,7 +19,6 @@ public class CosmeticBalloonType extends Cosmetic {
 
     private final String modelName;
     private List<String> dyableParts;
-    //private HashMap<Animations, String> animationBalloons;
 
     public CosmeticBalloonType(String id, ConfigurationNode config) {
         super(id, config);
@@ -27,17 +26,9 @@ public class CosmeticBalloonType extends Cosmetic {
         String modelId = config.node("model").getString();
 
         try {
-            if (!config.node("dyable-parts").virtual()) dyableParts = config.node("dyable-parts").getList(String.class);
-
-            /*
-            if (!config.node("animations").virtual()) {
-                for (ConfigurationNode animationNode : config.node("animations").childrenMap().values()) {
-                    if (EnumUtils.isValidEnum(Animations.class, animationNode.key().toString().toUpperCase())) continue;
-                    animationBalloons.put(Animations.valueOf(animationNode.key().toString().toUpperCase()), animationNode.getString());
-                }
+            if (!config.node("dyable-parts").virtual()) {
+                dyableParts = config.node("dyable-parts").getList(String.class);
             }
-             */
-
         } catch (SerializationException e) {
             // Seriously?
             throw new RuntimeException(e);
@@ -89,10 +80,4 @@ public class CosmeticBalloonType extends Cosmetic {
         if (dyableParts.isEmpty()) return true;
         return dyableParts.contains(name);
     }
-
-    /*
-    public String getAnimation(Animations animation) {
-        return animationBalloons.get(animation);
-    }
-     */
 }


### PR DESCRIPTION
This PR makes two minor changes:
- Makes [`Cosmetic.java`](https://github.com/HibiscusMC/HMCCosmetics/compare/remapped...Craftinators:HMCCosmetics:remapped?expand=1#diff-5a08552091085afe8aa23c80f7da8d96a399499fd9ce9be02b69dfdb40671c40) abstract to more accurately reflect its purpose.
- Moves `config` property in [`CosmeticBackpackType.java`](https://github.com/HibiscusMC/HMCCosmetics/compare/remapped...Craftinators:HMCCosmetics:remapped?expand=1#diff-1400fb6c8448a3712567a43df1ec72706e2a61ccaa50d7b8f3efe0209d164c14) to the constructor as it's not used anywhere else.