### PR TITLE
`CosmeticUser.getCosmetics()` changes

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
@@ -28,7 +28,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.Set;
 
 public class CosmeticCommand implements CommandExecutor {
@@ -333,7 +332,7 @@ public class CosmeticCommand implements CommandExecutor {
                 if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
                     player.sendMessage("Backpack Location -> " + user.getUserBackpackManager().getArmorStand().getLocation());
                 }
-                player.sendMessage("Cosmetics -> " + user.getCosmetic());
+                player.sendMessage("Cosmetics -> " + user.getCosmetics());
                 player.sendMessage("EntityId -> " + player.getEntityId());
                 return true;
             }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
@@ -56,7 +56,7 @@ public class CosmeticCommandTabComplete implements TabCompleter {
                     completions.addAll(applyCommandComplete(user, args));
                 }
                 case "unapply" -> {
-                    for (Cosmetic cosmetic : user.getCosmetic()) {
+                    for (Cosmetic cosmetic : user.getCosmetics()) {
                         completions.add(cosmetic.getSlot().toString().toUpperCase());
                     }
                     completions.add("ALL");

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/Data.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/Data.java
@@ -37,7 +37,7 @@ public abstract class Data {
                 data = "HIDDEN=" + user.getHiddenReason();
             }
         }
-        for (Cosmetic cosmetic : user.getCosmetic()) {
+        for (Cosmetic cosmetic : user.getCosmetics()) {
             Color color = user.getCosmeticColor(cosmetic.getSlot());
             String input = cosmetic.getSlot() + "=" + cosmetic.getId();
             if (color != null) input = input + "&" + color.asRGB();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
@@ -347,7 +347,7 @@ public class PlayerGameListener implements Listener {
 
                 HashMap<Integer, ItemStack> items = new HashMap<>();
 
-                for (Cosmetic cosmetic : user.getCosmetic()) {
+                for (Cosmetic cosmetic : user.getCosmetics()) {
                     if ((cosmetic instanceof CosmeticArmorType cosmeticArmorType)) {
                         items.put(InventoryUtils.getPacketArmorSlot(cosmeticArmorType.getEquipSlot()), user.getUserCosmeticItem(cosmeticArmorType));
                     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -1,5 +1,6 @@
 package com.hibiscusmc.hmccosmetics.user;
 
+import com.google.common.collect.ImmutableCollection;
 import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.api.*;
 import com.hibiscusmc.hmccosmetics.config.Settings;
@@ -84,6 +85,10 @@ public class CosmeticUser {
 
     public Collection<Cosmetic> getCosmetics() {
         return playerCosmetics.values();
+    }
+
+    public ImmutableCollection<Cosmetic> getPlayerCosmetics() {
+        return (ImmutableCollection<Cosmetic>) playerCosmetics.values();
     }
 
     public void addPlayerCosmetic(Cosmetic cosmetic) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -77,6 +77,11 @@ public class CosmeticUser {
         return playerCosmetics.get(slot);
     }
 
+    @Deprecated
+    public Collection<Cosmetic> getCosmetic() {
+        return playerCosmetics.values();
+    }
+
     public Collection<Cosmetic> getCosmetics() {
         return playerCosmetics.values();
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -77,8 +77,8 @@ public class CosmeticUser {
         return playerCosmetics.get(slot);
     }
 
-    public Collection<Cosmetic> getCosmetic() {
-        return playerCosmetics.values();
+    public Collection<Cosmetic> getCosmetics() {
+        return Collections.unmodifiableCollection(playerCosmetics.values());
     }
 
     public void addPlayerCosmetic(Cosmetic cosmetic) {
@@ -358,7 +358,7 @@ public class CosmeticUser {
     public List<CosmeticSlot> getDyeableSlots() {
         ArrayList<CosmeticSlot> dyableSlots = new ArrayList();
 
-        for (Cosmetic cosmetic : getCosmetic()) {
+        for (Cosmetic cosmetic : getCosmetics()) {
             if (cosmetic.isDyable()) dyableSlots.add(cosmetic.getSlot());
         }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -1,6 +1,7 @@
 package com.hibiscusmc.hmccosmetics.user;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.api.*;
 import com.hibiscusmc.hmccosmetics.config.Settings;
@@ -83,12 +84,8 @@ public class CosmeticUser {
         return playerCosmetics.values();
     }
 
-    public Collection<Cosmetic> getCosmetics() {
-        return playerCosmetics.values();
-    }
-
-    public ImmutableCollection<Cosmetic> getPlayerCosmetics() {
-        return (ImmutableCollection<Cosmetic>) playerCosmetics.values();
+    public ImmutableCollection<Cosmetic> getCosmetics() {
+        return ImmutableList.copyOf(playerCosmetics.values());
     }
 
     public void addPlayerCosmetic(Cosmetic cosmetic) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -78,7 +78,7 @@ public class CosmeticUser {
     }
 
     public Collection<Cosmetic> getCosmetics() {
-        return Collections.unmodifiableCollection(playerCosmetics.values());
+        return playerCosmetics.values();
     }
 
     public void addPlayerCosmetic(Cosmetic cosmetic) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserWardrobeManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserWardrobeManager.java
@@ -200,7 +200,7 @@ public class UserWardrobeManager {
             }
 
             // For Wardrobe Temp Cosmetics
-            for (Cosmetic cosmetic : user.getCosmetic()) {
+            for (Cosmetic cosmetic : user.getCosmetics()) {
                 if (cosmetic.requiresPermission()) {
                     if (!player.hasPermission(cosmetic.getPermission())) user.removeCosmeticSlot(cosmetic.getSlot());
                 }


### PR DESCRIPTION
This PR request changes the `CosmeticUser.getCosmetic()` method to `CosmeticUser.getCosmetics()` in order to improve the clarity and consistency of the codebase.

The change was made to reflect the fact that the method returns multiple cosmetic items rather than just one. The new method name is more accurate and easier to understand, making it more intuitive for developers to work with.

*All references to the old method name have been updated throughout the codebase, including in comments and documentation.*