### PR TITLE
Documentation of `/api` directory

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/CosmeticUserEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/CosmeticUserEvent.java
@@ -1,0 +1,26 @@
+package com.hibiscusmc.hmccosmetics.api;
+
+import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a cosmetic user related event
+ */
+public abstract class CosmeticUserEvent extends Event {
+    protected CosmeticUser user;
+
+    public CosmeticUserEvent(@NotNull final CosmeticUser who) {
+        user = who;
+    }
+
+    /**
+     * Returns the user involved in this event
+     *
+     * @return User who is involved in this event
+     */
+    @NotNull
+    public final CosmeticUser getUser() {
+        return user;
+    }
+}

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticSetupEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticSetupEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called when the plugin is enabled
+ * Called when the plugin is set up and/or reloaded
  */
 public class HMCCosmeticSetupEvent extends Event {
     private static final HandlerList handlers = new HandlerList();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticSetupEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticSetupEvent.java
@@ -4,12 +4,10 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when the plugin is enabled
+ */
 public class HMCCosmeticSetupEvent extends Event {
-
-    public HMCCosmeticSetupEvent() {
-        // Empty
-    }
-
     private static final HandlerList handlers = new HandlerList();
 
     @Override
@@ -18,6 +16,7 @@ public class HMCCosmeticSetupEvent extends Event {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
@@ -20,7 +20,7 @@ public class PlayerCosmeticEquipEvent extends CosmeticUserEvent implements Cance
     }
 
     /**
-     * Gets the {@link Cosmetic} being equipped in this event.
+     * Gets the {@link Cosmetic} being equipped in this event
      *
      * @return The {@link Cosmetic} which is being equipped in this event
      */
@@ -44,10 +44,10 @@ public class PlayerCosmeticEquipEvent extends CosmeticUserEvent implements Cance
     }
 
     /**
-     * Sets the cancellation state of this event.
+     * Sets the cancellation state of this event
      *
      * <p>
-     * Canceling this event will prevent the player from equipping the cosmetic.
+     * Canceling this event will prevent the player from equipping the cosmetic
      * </p>
      *
      * @param cancel true if you wish to cancel this event

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
@@ -20,9 +20,9 @@ public class PlayerCosmeticEquipEvent extends CosmeticUserEvent implements Cance
     }
 
     /**
-     * Gets the cosmetic being equipped in this event.
+     * Gets the {@link Cosmetic} being equipped in this event.
      *
-     * @return The {@link Cosmetic} which is being equipped in this event.
+     * @return The {@link Cosmetic} which is being equipped in this event
      */
     @NotNull
     public Cosmetic getCosmetic() {
@@ -30,9 +30,9 @@ public class PlayerCosmeticEquipEvent extends CosmeticUserEvent implements Cance
     }
 
     /**
-     * Sets the cosmetic that the player will equip
+     * Sets the {@link Cosmetic} that the player will equip
      *
-     * @param cosmetic The cosmetic that the player will equip
+     * @param cosmetic The {@link Cosmetic} that the player will equip
      */
     public void setCosmetic(@NotNull Cosmetic cosmetic) {
         this.cosmetic = cosmetic;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player equips a cosmetic
  */
-public class PlayerCosmeticEquipEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerCosmeticEquipEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private Cosmetic cosmetic;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEquipEvent.java
@@ -3,33 +3,59 @@ package com.hibiscusmc.hmccosmetics.api;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerCosmeticEquipEvent extends Event implements Cancellable {
-
-    private final CosmeticUser user;
+/**
+ * Called when a player equips a cosmetic
+ */
+public class PlayerCosmeticEquipEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
     private Cosmetic cosmetic;
-    private boolean isCancelled;
 
-    public PlayerCosmeticEquipEvent(CosmeticUser user, Cosmetic cosmetic) {
-        this.user = user;
+    public PlayerCosmeticEquipEvent(@NotNull CosmeticUser who, @NotNull Cosmetic cosmetic) {
+        super(who);
         this.cosmetic = cosmetic;
-        this.isCancelled = false;
+    }
+
+    /**
+     * Gets the cosmetic being equipped in this event.
+     *
+     * @return The {@link Cosmetic} which is being equipped in this event.
+     */
+    @NotNull
+    public Cosmetic getCosmetic() {
+        return cosmetic;
+    }
+
+    /**
+     * Sets the cosmetic that the player will equip
+     *
+     * @param cosmetic The cosmetic that the player will equip
+     */
+    public void setCosmetic(@NotNull Cosmetic cosmetic) {
+        this.cosmetic = cosmetic;
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event.
+     *
+     * <p>
+     * Canceling this event will prevent the player from equipping the cosmetic.
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -37,19 +63,8 @@ public class PlayerCosmeticEquipEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
-    }
-
-    public Cosmetic getCosmetic() {
-        return cosmetic;
-    }
-
-    public void setCosmetic(Cosmetic cosmetic) {
-        this.cosmetic = cosmetic;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticEvent.java
@@ -7,10 +7,10 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Represents a cosmetic user related event
  */
-public abstract class CosmeticUserEvent extends Event {
+public abstract class PlayerCosmeticEvent extends Event {
     protected CosmeticUser user;
 
-    public CosmeticUserEvent(@NotNull final CosmeticUser who) {
+    public PlayerCosmeticEvent(@NotNull final CosmeticUser who) {
         user = who;
     }
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
@@ -34,10 +34,10 @@ public class PlayerCosmeticHideEvent extends CosmeticUserEvent implements Cancel
     }
 
     /**
-     * Sets the cancellation state of this event.
+     * Sets the cancellation state of this event
      *
      * <p>
-     * Canceling this event will prevent the player from hiding cosmetics.
+     * Canceling this event will prevent the player from hiding cosmetics
      * </p>
      *
      * @param cancel true if you wish to cancel this event

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when cosmetics are hidden from a player
  */
-public class PlayerCosmeticHideEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerCosmeticHideEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private final CosmeticUser.HiddenReason reason;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticHideEvent.java
@@ -2,33 +2,50 @@ package com.hibiscusmc.hmccosmetics.api;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerCosmeticHideEvent extends Event implements Cancellable {
-
-    private final CosmeticUser user;
+/**
+ * Called when cosmetics are hidden from a player
+ */
+public class PlayerCosmeticHideEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
     private final CosmeticUser.HiddenReason reason;
-    private boolean isCancelled;
 
-    public PlayerCosmeticHideEvent(CosmeticUser user, CosmeticUser.HiddenReason reason) {
-        this.user = user;
+    public PlayerCosmeticHideEvent(@NotNull CosmeticUser who, @NotNull CosmeticUser.HiddenReason reason) {
+        super(who);
         this.reason = reason;
-        this.isCancelled = false;
+    }
+
+    /**
+     * Gets the {@link CosmeticUser.HiddenReason} as to why cosmetics are being hidden for the player
+     *
+     * @return The {@link CosmeticUser.HiddenReason} why cosmetics are being hidden for the player
+     */
+    @NotNull
+    public CosmeticUser.HiddenReason getReason() {
+        return reason;
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event.
+     *
+     * <p>
+     * Canceling this event will prevent the player from hiding cosmetics.
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -36,14 +53,8 @@ public class PlayerCosmeticHideEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
-    }
-    public CosmeticUser.HiddenReason getReason() {
-        return reason;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticRemoveEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticRemoveEvent.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player removes a cosmetic
  */
-public class PlayerCosmeticRemoveEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerCosmeticRemoveEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private final Cosmetic cosmetic;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticRemoveEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticRemoveEvent.java
@@ -3,33 +3,49 @@ package com.hibiscusmc.hmccosmetics.api;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerCosmeticRemoveEvent extends Event implements Cancellable {
-
-    private final CosmeticUser user;
+/**
+ * Called when a player removes a cosmetic
+ */
+public class PlayerCosmeticRemoveEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
     private final Cosmetic cosmetic;
-    private boolean isCancelled;
 
-    public PlayerCosmeticRemoveEvent(CosmeticUser user, Cosmetic cosmetic) {
-        this.user = user;
+    public PlayerCosmeticRemoveEvent(@NotNull CosmeticUser who, @NotNull Cosmetic cosmetic) {
+        super(who);
         this.cosmetic = cosmetic;
-        this.isCancelled = false;
+    }
+
+    /**
+     * Gets the {@link Cosmetic} being removed in this event
+     *
+     * @return The {@link Cosmetic} which is being removed in this event
+     */
+    public Cosmetic getCosmetic() {
+        return cosmetic;
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from removing the cosmetic
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -39,13 +55,5 @@ public class PlayerCosmeticRemoveEvent extends Event implements Cancellable {
 
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
-    }
-
-    public Cosmetic getCosmetic() {
-        return cosmetic;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
@@ -6,27 +6,35 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerCosmeticShowEvent extends Event implements Cancellable {
+/**
+ * Called when cosmetics are shown from a player
+ */
+public class PlayerCosmeticShowEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
 
-    private final CosmeticUser user;
-    private boolean isCancelled;
-
-    public PlayerCosmeticShowEvent(CosmeticUser user) {
-        this.user = user;
-        this.isCancelled = false;
+    public PlayerCosmeticShowEvent(@NotNull CosmeticUser who) {
+        super(who);
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from showing cosmetics
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -34,11 +42,8 @@ public class PlayerCosmeticShowEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when cosmetics are shown from a player
  */
-public class PlayerCosmeticShowEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerCosmeticShowEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerCosmeticShowEvent.java
@@ -2,7 +2,6 @@ package com.hibiscusmc.hmccosmetics.api;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStartEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStartEvent.java
@@ -2,33 +2,51 @@ package com.hibiscusmc.hmccosmetics.api;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerEmoteStartEvent extends Event implements Cancellable {
+/**
+ * Called when a player starts playing an emote
+ */
+public class PlayerEmoteStartEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private final String animationId;
 
-    private final CosmeticUser user;
-    private String animationId; // Animation id can be invalid!
-    private boolean isCancelled;
-
-    public PlayerEmoteStartEvent(CosmeticUser user, String animationId) {
-        this.user = user;
+    public PlayerEmoteStartEvent(@NotNull CosmeticUser who, @NotNull String animationId) {
+        super(who);
         this.animationId = animationId;
-        this.isCancelled = false;
+    }
+
+    /**
+     * Gets the animation id of the emote the player started playing
+     * @implNote The returned string of this method may be an invalid animation id. Make sure to validate it before use
+     *
+     * @return The animation id of the emote which the player started playing
+     */
+    @NotNull
+    public String getAnimationId() {
+        return animationId;
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from playing the emote
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -36,15 +54,8 @@ public class PlayerEmoteStartEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
-    }
-
-    public String getAnimationId() {
-        return animationId;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStartEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStartEvent.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player starts playing an emote
  */
-public class PlayerEmoteStartEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerEmoteStartEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private final String animationId;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStopEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStopEvent.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player stops playing an emote
  */
-public class PlayerEmoteStopEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerEmoteStopEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
     private final UserEmoteManager.StopEmoteReason reason;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStopEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStopEvent.java
@@ -6,6 +6,9 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when a player stops playing an emote
+ */
 public class PlayerEmoteStopEvent extends CosmeticUserEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStopEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerEmoteStopEvent.java
@@ -3,33 +3,60 @@ package com.hibiscusmc.hmccosmetics.api;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.user.manager.UserEmoteManager;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerEmoteStopEvent extends Event implements Cancellable {
+public class PlayerEmoteStopEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private final UserEmoteManager.StopEmoteReason reason;
 
-    private final CosmeticUser user;
-    private final UserEmoteManager.StopEmoteReason stopEmoteReason;
-    private boolean isCancelled;
+    public PlayerEmoteStopEvent(@NotNull CosmeticUser who, @NotNull UserEmoteManager.StopEmoteReason reason) {
+        super(who);
+        this.reason = reason;
+    }
 
-    public PlayerEmoteStopEvent(CosmeticUser user, UserEmoteManager.StopEmoteReason reason) {
-        this.user = user;
-        this.stopEmoteReason = reason;
-        this.isCancelled = false;
+    /**
+     * Gets the {@link UserEmoteManager.StopEmoteReason} as to why the emote has stopped playing
+     *
+     * @return The {@link UserEmoteManager.StopEmoteReason} why the emote has stopped playing
+     * @deprecated As of release 2.2.5+, replaced by {@link #getReason()}
+     */
+    @Deprecated
+    @NotNull
+    public UserEmoteManager.StopEmoteReason getStopEmoteReason() {
+        return reason;
+    }
+
+    /**
+     * Gets the {@link UserEmoteManager.StopEmoteReason} as to why the emote has stopped playing
+     *
+     * @return The {@link UserEmoteManager.StopEmoteReason} why the emote has stopped playing
+     * @since 2.2.5
+     */
+    @NotNull
+    public UserEmoteManager.StopEmoteReason getReason() {
+        return reason;
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from stopping the emote
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -37,15 +64,8 @@ public class PlayerEmoteStopEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
-    }
-
-    public UserEmoteManager.StopEmoteReason getStopEmoteReason() {
-        return stopEmoteReason;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuCloseEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuCloseEvent.java
@@ -9,24 +9,12 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a menu is closed by a player
  */
-public class PlayerMenuCloseEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerMenuCloseEvent extends PlayerMenuEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
-    private final Menu menu;
 
     public PlayerMenuCloseEvent(@NotNull CosmeticUser who, @NotNull Menu menu) {
-        super(who);
-        this.menu = menu;
-    }
-
-    /**
-     * Gets the {@link Menu} that the player closed
-     *
-     * @return The {@link Menu} which is being closed by the player
-     */
-    @NotNull
-    public Menu getMenu() {
-        return menu;
+        super(who, menu);
     }
 
     @Override

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuCloseEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuCloseEvent.java
@@ -2,38 +2,17 @@ package com.hibiscusmc.hmccosmetics.api;
 
 import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a menu is closed by a player
  */
-public class PlayerMenuCloseEvent extends PlayerMenuEvent implements Cancellable {
+public class PlayerMenuCloseEvent extends PlayerMenuEvent {
     private static final HandlerList handlers = new HandlerList();
-    private boolean cancel = false;
 
     public PlayerMenuCloseEvent(@NotNull CosmeticUser who, @NotNull Menu menu) {
         super(who, menu);
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return cancel;
-    }
-
-    /**
-     * Sets the cancellation state of this event
-     *
-     * <p>
-     * Canceling this event will prevent the player from closing a {@link Menu}
-     * </p>
-     *
-     * @param cancel true if you wish to cancel this event
-     */
-    @Override
-    public void setCancelled(boolean cancel) {
-        this.cancel = cancel;
     }
 
     @Override

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuCloseEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuCloseEvent.java
@@ -1,0 +1,61 @@
+package com.hibiscusmc.hmccosmetics.api;
+
+import com.hibiscusmc.hmccosmetics.gui.Menu;
+import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a menu is closed by a player
+ */
+public class PlayerMenuCloseEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
+    private final Menu menu;
+
+    public PlayerMenuCloseEvent(@NotNull CosmeticUser who, @NotNull Menu menu) {
+        super(who);
+        this.menu = menu;
+    }
+
+    /**
+     * Gets the {@link Menu} that the player closed
+     *
+     * @return The {@link Menu} which is being closed by the player
+     */
+    @NotNull
+    public Menu getMenu() {
+        return menu;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from closing a {@link Menu}
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    @NotNull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuEvent.java
@@ -1,0 +1,27 @@
+package com.hibiscusmc.hmccosmetics.api;
+
+import com.hibiscusmc.hmccosmetics.gui.Menu;
+import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a menu related event
+ */
+public abstract class PlayerMenuEvent extends PlayerCosmeticEvent {
+    protected Menu menu;
+
+    public PlayerMenuEvent(@NotNull CosmeticUser who, @NotNull Menu menu) {
+        super(who);
+        this.menu = menu;
+    }
+
+    /**
+     * Gets the {@link Menu} involved with this event
+     *
+     * @return The {@link Menu} which is involved with the event
+     */
+    @NotNull
+    public final Menu getMenu() {
+        return menu;
+    }
+}

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
@@ -6,6 +6,9 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when a menu is opened by a player
+ */
 public class PlayerMenuOpenEvent extends CosmeticUserEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
@@ -17,7 +20,7 @@ public class PlayerMenuOpenEvent extends CosmeticUserEvent implements Cancellabl
     }
 
     /**
-     * Gets the {@link Menu} that the player is opening
+     * Gets the {@link Menu} that the player opened
      *
      * @return The {@link Menu} which is being opened by the player
      */

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
@@ -3,33 +3,47 @@ package com.hibiscusmc.hmccosmetics.api;
 import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerMenuOpenEvent extends Event implements Cancellable {
-
-    private final CosmeticUser user;
+public class PlayerMenuOpenEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
     private final Menu menu;
-    private boolean isCancelled;
 
-    public PlayerMenuOpenEvent(CosmeticUser user, Menu menu) {
-        this.user = user;
+    public PlayerMenuOpenEvent(@NotNull CosmeticUser who, @NotNull Menu menu) {
+        super(who);
         this.menu = menu;
-        this.isCancelled = false;
+    }
+
+    /**
+     * Gets the {@link Menu} that the player is opening
+     *
+     * @return The {@link Menu} which is being opened by the player
+     */
+    @NotNull
+    public Menu getMenu() {
+        return menu;
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from opening a {@link Menu}
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -37,15 +51,8 @@ public class PlayerMenuOpenEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
-    }
-
-    public Menu getMenu() {
-        return menu;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerMenuOpenEvent.java
@@ -9,24 +9,12 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a menu is opened by a player
  */
-public class PlayerMenuOpenEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerMenuOpenEvent extends PlayerMenuEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
-    private final Menu menu;
 
     public PlayerMenuOpenEvent(@NotNull CosmeticUser who, @NotNull Menu menu) {
-        super(who);
-        this.menu = menu;
-    }
-
-    /**
-     * Gets the {@link Menu} that the player opened
-     *
-     * @return The {@link Menu} which is being opened by the player
-     */
-    @NotNull
-    public Menu getMenu() {
-        return menu;
+        super(who, menu);
     }
 
     @Override

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
@@ -5,6 +5,9 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when a player enters their wardrobe
+ */
 public class PlayerWardrobeEnterEvent extends CosmeticUserEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player enters their wardrobe
  */
-public class PlayerWardrobeEnterEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerWardrobeEnterEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeEnterEvent.java
@@ -2,31 +2,35 @@ package com.hibiscusmc.hmccosmetics.api;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerWardrobeEnterEvent extends Event implements Cancellable {
+public class PlayerWardrobeEnterEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
 
-    private final CosmeticUser user;
-    private boolean isCancelled;
-
-    public PlayerWardrobeEnterEvent(CosmeticUser user) {
-        this.user = user;
-        this.isCancelled = false;
+    public PlayerWardrobeEnterEvent(@NotNull CosmeticUser who) {
+        super(who);
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from entering their wardrobe
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -34,11 +38,8 @@ public class PlayerWardrobeEnterEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player leaves their wardrobe
  */
-public class PlayerWardrobeLeaveEvent extends CosmeticUserEvent implements Cancellable {
+public class PlayerWardrobeLeaveEvent extends PlayerCosmeticEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
@@ -5,6 +5,9 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Called when a player leaves their wardrobe
+ */
 public class PlayerWardrobeLeaveEvent extends CosmeticUserEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean cancel = false;

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/PlayerWardrobeLeaveEvent.java
@@ -2,31 +2,35 @@ package com.hibiscusmc.hmccosmetics.api;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerWardrobeLeaveEvent extends Event implements Cancellable {
+public class PlayerWardrobeLeaveEvent extends CosmeticUserEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancel = false;
 
-    private final CosmeticUser user;
-    private boolean isCancelled;
-
-    public PlayerWardrobeLeaveEvent(CosmeticUser user) {
-        this.user = user;
-        this.isCancelled = false;
+    public PlayerWardrobeLeaveEvent(@NotNull CosmeticUser who) {
+        super(who);
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        return cancel;
     }
 
+    /**
+     * Sets the cancellation state of this event
+     *
+     * <p>
+     * Canceling this event will prevent the player from leaving their wardrobe
+     * </p>
+     *
+     * @param cancel true if you wish to cancel this event
+     */
     @Override
     public void setCancelled(boolean cancel) {
-        isCancelled = cancel;
+        this.cancel = cancel;
     }
-
-    private static final HandlerList handlers = new HandlerList();
 
     @Override
     @NotNull
@@ -34,11 +38,8 @@ public class PlayerWardrobeLeaveEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
-    }
-
-    public CosmeticUser getUser() {
-        return user;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserEmoteManager.java
@@ -1,6 +1,5 @@
 package com.hibiscusmc.hmccosmetics.user.manager;
 
-import com.hibiscusmc.hmccosmetics.api.PlayerCosmeticRemoveEvent;
 import com.hibiscusmc.hmccosmetics.api.PlayerEmoteStartEvent;
 import com.hibiscusmc.hmccosmetics.api.PlayerEmoteStopEvent;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticEmoteType;


### PR DESCRIPTION
The purpose of this PR is to document of the source code inside the `common/.../com.hibiscusmc.hmccosmetics/api` directory.

#### New Features
- [`PlayerCosmeticEvent`](https://github.com/HibiscusMC/HMCCosmetics/pull/81/files#diff-92d9af380e3d8731cd7c6fb5f54305254260627500cd3283b8a1a043e7df6043)
- [`PlayerMenuCloseEvent`](https://github.com/HibiscusMC/HMCCosmetics/pull/81/files#diff-dd77e2eb89a312f24c7aae2a98dc0740bae77d2940f515d72c7f2ca826af95fb)
> **Note** These two classes were made as an abstraction of the `CosmeticUser` and `Menu` properties and their getters, respectively.
- [PlayerMenuCloseEvent.java](https://github.com/HibiscusMC/HMCCosmetics/pull/81/files#diff-dd77e2eb89a312f24c7aae2a98dc0740bae77d2940f515d72c7f2ca826af95fb)
> Didn't make sense for there to be a `PlayerMenuOpenEvent` and not a counterpart, so it was added.

#### 🔖 Documented files
- [x] `/api`
  - [X] `PlayerCosmeticEvent` 
  - [x] `HMCCosmeticSetupEvent`
  - [X] `PlayerCosmeticEquipEvent`
  - [x] `PlayerCosmeticHideEvent`
  - [x] `PlayerCosmeticRemoveEvent`
  - [x] `PlayerCosmeticShowEvent`
  - [x] `PlayerEmoteStartEvent`
  - [x] `PlayerEmoteStopEvent`
  - [x] `PlayerMenuOpenEvent`
  - [x] `PlayerWardrobeEnterEvent`
  - [x] `PlayerWardrobeLeaveEvent`