### PR TITLE
Add support for Denizen items

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,8 @@ allprojects {
         //Hikari
         maven("https://mvnrepository.com/artifact/com.zaxxer/HikariCP")
 
-        // Citizens
-        maven("https://repo.citizensnpcs.co")
+        // Citizens & Denizen
+        maven("https://maven.citizensnpcs.co/repo")
 
         // Worldguard
         maven("https://maven.enginehub.org/repo/")
@@ -168,7 +168,7 @@ bukkit {
     apiVersion = "1.17"
     authors = listOf("LoJoSho")
     depend = listOf("ProtocolLib")
-    softDepend = listOf("ModelEngine", "Oraxen", "ItemsAdder", "Looty", "HMCColor", "WorldGuard", "MythicMobs", "PlaceholderAPI", "SuperVanish", "PremiumVanish")
+    softDepend = listOf("ModelEngine", "Oraxen", "ItemsAdder", "Looty", "HMCColor", "WorldGuard", "MythicMobs", "Denizen", "PlaceholderAPI", "SuperVanish", "PremiumVanish")
     version = "${project.version}"
 
     commands {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.1.0-SNAPSHOT")
     compileOnly("it.unimi.dsi:fastutil:8.5.11")
     compileOnly("io.lumine:Mythic-Dist:5.2.1")
+    compileOnly("com.denizenscript:denizen:1.2.7-SNAPSHOT")
     compileOnly("com.github.LeonMangler:SuperVanish:6.2.6-4")
 
     //compileOnly("com.github.Fisher2911:FisherLib:master-SNAPSHOT")

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/Hooks.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/Hooks.java
@@ -22,6 +22,7 @@ public class Hooks {
     private static HookItemAdder ITEMADDER_HOOK = new HookItemAdder();
     private static HookLooty LOOTY_HOOK = new HookLooty();
     private static HookMythic MYTHIC_HOOK = new HookMythic();
+    private static HookDenizen DENIZEN_HOOK = new HookDenizen();
     private static HookHMCCosmetics HMCCOSMETIC_HOOK = new HookHMCCosmetics();
     private static HookPlaceholderAPI PAPI_HOOK = new HookPlaceholderAPI();
     private static HookPremiumVanish PREMIUM_VANISH_HOOK = new HookPremiumVanish();

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookDenizen.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/items/HookDenizen.java
@@ -1,0 +1,27 @@
+package com.hibiscusmc.hmccosmetics.hooks.items;
+
+import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.hibiscusmc.hmccosmetics.hooks.Hook;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A hook that integrates the plugin {@link com.denizenscript.denizen.Denizen Denizen} to provide custom items
+ */
+@SuppressWarnings("SpellCheckingInspection")
+public class HookDenizen extends Hook {
+    public HookDenizen() {
+        super("denizen");
+        setEnabledItemHook(true);
+    }
+
+    /**
+     * Gets a cosmetic {@link ItemStack} that is associated with the provided id from the plugin {@link com.denizenscript.denizen.Denizen Denizen}
+     */
+    @Override
+    public ItemStack getItem(@NotNull String itemId) {
+        ItemTag item = ItemTag.valueOf(itemId, CoreUtilities.noDebugContext);
+        return item == null ? null : item.getItemStack();
+    }
+}


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [ ] Major breaking change
- [ ] Minor change
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation
- [ ] Cleaning
- [ ] Refactoring

#### Please describe the changes this PR makes and why it should be merged:
Denizen is a powerful scripting language primarily used for Citizens NPCs, but also has a large community of users who use it for general-purpose scripting. This PR adds support for Denizen scripted items.

Tested via:
```yaml
# Denizen script
custom_item:
  type: item
  material: blaze_rod
  display name: <&gradient[from=#00ff00;to=#0000ff]>My custom item
  mechanisms:
    custom_model_data: 1
  lore:
    - Some lore, <util.time_now.format>
```

```yaml
# Cosmetic linked to script
custom_item:
  slot: OFFHAND
  permission: "hmccosmetics.custom_item"
  item:
    material: denizen:custom_item
```
![image](https://user-images.githubusercontent.com/29823405/235312849-5e615b05-cbcd-416b-ade8-641011b0eb3c.png)

#### Check that:
- [x] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [x] Syntax and style are consistent with existing code
- [x] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
