### PR TITLE
Improved GUI configuration options (2.3.0)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.hibiscusmc"
-version = "2.2.9-DEV"
+version = "2.3.0-DEV"
 
 allprojects {
     apply(plugin = "java")

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetic.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/Cosmetic.java
@@ -17,6 +17,7 @@ public abstract class Cosmetic {
     private String id;
     private String permission;
     private ItemStack item;
+    private String material;
     private CosmeticSlot slot;
     private boolean dyable;
 
@@ -29,7 +30,10 @@ public abstract class Cosmetic {
             this.permission = null;
         }
 
-        if (!config.node("item").virtual()) this.item = generateItemStack(config.node("item"));
+        if (!config.node("item").virtual()) {
+            this.material = config.node("item", "material").getString();
+            this.item = generateItemStack(config.node("item"));
+        }
 
         MessagesUtil.sendDebugMessages("Slot: " + config.node("slot").getString());
 
@@ -74,6 +78,10 @@ public abstract class Cosmetic {
 
     public boolean isDyable() {
         return this.dyable;
+    }
+
+    public String getMaterial() {
+        return material;
     }
 
     public abstract void update(CosmeticUser user);

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
@@ -144,10 +144,8 @@ public class Menu {
             }
 
             for (int slot : slots) {
-                ItemStack originalItem = item.clone();
-                item = updateItem(user, item, type, config, slot);
-
-                GuiItem guiItem = ItemBuilder.from(item).asGuiItem();
+                ItemStack originalItem = updateItem(user, item, type, config, slot).clone();
+                GuiItem guiItem = ItemBuilder.from(originalItem).asGuiItem();
 
                 Type finalType = type;
                 guiItem.setAction(event -> {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
@@ -156,7 +156,6 @@ public class Menu {
                     for (int guiSlot : slots) {
                         gui.updateItem(guiSlot, updateItem(user, originalItem.clone(), finalType, config, guiSlot));
                     }
-                    gui.update();
                     MessagesUtil.sendDebugMessages("Updated slot " + slot);
                 });
 

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/Type.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/Type.java
@@ -2,6 +2,7 @@ package com.hibiscusmc.hmccosmetics.gui.type;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.spongepowered.configurate.ConfigurationNode;
 
@@ -24,5 +25,5 @@ public abstract class Type {
 
     public abstract void run(CosmeticUser user, ConfigurationNode config, ClickType clickType);
 
-    public abstract ItemMeta setLore(CosmeticUser user, ConfigurationNode config, ItemMeta itemMeta);
+    public abstract ItemStack setItem(CosmeticUser user, ConfigurationNode config, ItemStack itemStack);
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeCosmetic.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeCosmetic.java
@@ -1,6 +1,7 @@
 package com.hibiscusmc.hmccosmetics.gui.type.types;
 
 import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
+import com.hibiscusmc.hmccosmetics.config.serializer.ItemSerializer;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetics;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticArmorType;
@@ -17,12 +18,14 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 
+import java.lang.invoke.TypeDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -96,55 +99,51 @@ public class TypeCosmetic extends Type {
     }
 
     @Override
-    public ItemMeta setLore(CosmeticUser user, @NotNull ConfigurationNode config, ItemMeta itemMeta) {
-        List<String> processedLore = new ArrayList<>();
+    public ItemStack setItem(CosmeticUser user, @NotNull ConfigurationNode config, ItemStack itemStack) {
+        ItemMeta itemMeta = itemStack.getItemMeta();
 
-        if (config.node("cosmetic").virtual()) return processLoreLines(user, itemMeta);;
+        if (config.node("cosmetic").virtual()) {
+            itemStack.setItemMeta(processLoreLines(user, itemMeta));
+            return itemStack;
+        };
         String cosmeticName = config.node("cosmetic").getString();
         Cosmetic cosmetic = Cosmetics.getCosmetic(cosmeticName);
         if (cosmetic == null) {
-            return processLoreLines(user, itemMeta);
+            itemStack.setItemMeta(processLoreLines(user, itemMeta));
+            return itemStack;
         }
 
-        if (user.canEquipCosmetic(cosmetic)) {
-            return processLoreLines(user, itemMeta);
-        } else {
-            ConfigurationNode itemConfig = config.node("item");
-            if (itemConfig.virtual()) return itemMeta;
-            if (itemConfig.node("locked-name").virtual() && itemConfig.node("locked-lore").virtual()) {
-                return processLoreLines(user, itemMeta);
+        if (user.hasCosmeticInSlot(cosmetic) && !config.node("equipped-item").virtual()) {
+            ConfigurationNode equippedItem = config.node("equipped-item");
+            try {
+                if (equippedItem.node("material").virtual()) equippedItem.node("material").set(config.node("item", "material").getString());
+            } catch (SerializationException e) {
+                // Nothing >:)
             }
             try {
-                List<String> lockedLore = itemMeta.getLore();
-                String lockedName = itemMeta.getDisplayName();
-
-                if (!itemConfig.node("locked-lore").virtual()) {
-                    lockedLore = Utils.replaceIfNull(itemConfig.node("locked-lore").getList(String.class),
-                                    new ArrayList<String>()).
-                            stream().map(StringUtils::parseStringToString).collect(Collectors.toList());
-                }
-                if (!itemConfig.node("locked-name").virtual()) {
-                    lockedName = StringUtils.parseStringToString(Utils.replaceIfNull(itemConfig.node("locked-name").getString(), ""));
-                }
-
-                if (Hooks.isActiveHook("PlaceHolderAPI")) {
-                    lockedName = PlaceholderAPI.setPlaceholders(user.getPlayer(), lockedName);
-                }
-                itemMeta.setDisplayName(lockedName);
-                if (itemMeta.hasLore()) {
-                    itemMeta.getLore().clear();
-                    for (String loreLine : lockedLore) {
-                        if (Hooks.isActiveHook("PlaceHolderAPI")) loreLine = PlaceholderAPI.setPlaceholders(user.getPlayer(), loreLine);
-                        processedLore.add(loreLine);
-                    }
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
+                itemStack = ItemSerializer.INSTANCE.deserialize(ItemStack.class, equippedItem);
+            } catch (SerializationException e) {
+                throw new RuntimeException(e);
             }
+            return itemStack;
         }
 
-        itemMeta.setLore(processedLore);
-        return itemMeta;
+        if (!user.canEquipCosmetic(cosmetic) && !config.node("locked-item").virtual()) {
+            ConfigurationNode lockedItem = config.node("locked-item");
+            try {
+                if (lockedItem.node("material").virtual()) lockedItem.node("material").set(config.node("item", "material").getString());
+            } catch (SerializationException e) {
+                // Nothing >:)
+            }
+            try {
+                itemStack = ItemSerializer.INSTANCE.deserialize(ItemStack.class, lockedItem);
+                //item = config.node("item").get(ItemStack.class);
+            } catch (SerializationException e) {
+                throw new RuntimeException(e);
+            }
+            return itemStack;
+        }
+        return itemStack;
     }
 
     @Contract("_, _ -> param2")

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeEmpty.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeEmpty.java
@@ -6,6 +6,7 @@ import com.hibiscusmc.hmccosmetics.hooks.Hooks;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
@@ -53,8 +54,9 @@ public class TypeEmpty extends Type {
 
     @Override
     @SuppressWarnings("Duplicates")
-    public ItemMeta setLore(CosmeticUser user, ConfigurationNode config, @NotNull ItemMeta itemMeta) {
+    public ItemStack setItem(CosmeticUser user, ConfigurationNode config, @NotNull ItemStack itemStack) {
         List<String> processedLore = new ArrayList<>();
+        ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (itemMeta.hasLore()) {
             for (String loreLine : itemMeta.getLore()) {
@@ -63,8 +65,8 @@ public class TypeEmpty extends Type {
                 processedLore.add(loreLine);
             }
         }
-
-        return itemMeta;
+        itemStack.setItemMeta(itemMeta);
+        return itemStack;
     }
 
     // That's it! Now, add it as a static in another one of your classes (such as your main class) and you are good to go.

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -156,6 +156,14 @@ public class CosmeticUser {
         return playerCosmetics.containsKey(slot);
     }
 
+    public boolean hasCosmeticInSlot(Cosmetic cosmetic) {
+        if (getCosmetic(cosmetic.getSlot()) == null) return true;
+        if (cosmetic.getId() == getCosmetic(cosmetic.getSlot()).getId()) {
+            return true;
+        }
+        return false;
+    }
+
     public Set<CosmeticSlot> getSlotsWithCosmetics() {
         return Set.copyOf(playerCosmetics.keySet());
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -157,7 +157,7 @@ public class CosmeticUser {
     }
 
     public boolean hasCosmeticInSlot(Cosmetic cosmetic) {
-        if (getCosmetic(cosmetic.getSlot()) == null) return true;
+        if (getCosmetic(cosmetic.getSlot()) == null) return false;
         if (cosmetic.getId() == getCosmetic(cosmetic.getSlot()).getId()) {
             return true;
         }


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [X] Major breaking change
- [ ] Minor change
- [X] Feature implementation
- [ ] Bug fix
- [ ] Chore (Changes that don't fix or add new features *and don't* modify source files)
- [ ] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [ ] Documentation (Changes to README files and/or JavaDocs)
- [ ] Style (Changes that don't affect the meaning of the code)
- [ ] Performance
- [ ] Other (Please specify below)

#### Please describe the changes this PR makes and why it should be merged:
This makes the internal GUI more useful to server owners by adding equipped-items and locked-items to the gui under the item type of cosmetic. This PR will break compatibility with 2.2.x locked-name and locked-lore configuration options. Instead, server operators should move to this new system. An example can be found below:

```yaml
  cosmeticsystem:
    slots:
      - 21
      - 22
      - 23
      - 24
    item:
      material: "paper"
      name: "<#d24c9f>Example Cosmetic Items - Earth Day Grabber"
      amount: 1
    equipped-item: # New equipped item area to build another item! And ooo, it takes after the material on the item!
      name: "This cosmetic has been equipped!"
    locked-item: # Locked item now it's own seperate thing! It can take after the item above, or you can assign it's own item!
      material: "BARRIER"
      name: "LOCKED!"
```

#### Check that:
- [X] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [X] Syntax and style are consistent with existing code
- [X] *Any* replaced method isn't deleted, but rather labeled as deprecated 
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
