### PR TITLE
feat: allow for multiple emotes in one bbmodel file

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/HMCCosmeticsPlugin.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/HMCCosmeticsPlugin.java
@@ -11,6 +11,7 @@ import com.hibiscusmc.hmccosmetics.config.serializer.LocationSerializer;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetics;
 import com.hibiscusmc.hmccosmetics.database.Database;
+import com.hibiscusmc.hmccosmetics.emotes.EmoteManager;
 import com.hibiscusmc.hmccosmetics.gui.Menus;
 import com.hibiscusmc.hmccosmetics.hooks.Hooks;
 import com.hibiscusmc.hmccosmetics.hooks.worldguard.WGHook;
@@ -25,9 +26,6 @@ import com.hibiscusmc.hmccosmetics.util.TranslationUtil;
 import com.jeff_media.updatechecker.UpdateCheckSource;
 import com.jeff_media.updatechecker.UpdateChecker;
 import com.ticxo.playeranimator.PlayerAnimatorImpl;
-import com.ticxo.playeranimator.api.PlayerAnimator;
-import com.ticxo.playeranimator.api.animation.pack.AnimationPack;
-import org.apache.commons.io.FilenameUtils;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -43,9 +41,6 @@ import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 public final class HMCCosmeticsPlugin extends JavaPlugin {
 
@@ -56,7 +51,6 @@ public final class HMCCosmeticsPlugin extends JavaPlugin {
     private static boolean hasModelEngine = false;
     private static boolean onLatestVersion = true;
     private static String latestVersion = "";
-    private static final Map<String, String> emoteMap = new HashMap<>();
 
     @Override
     public void onEnable() {
@@ -243,7 +237,7 @@ public final class HMCCosmeticsPlugin extends JavaPlugin {
             }
         }
 
-        loadEmotes();
+        EmoteManager.loadEmotes();
 
         getInstance().getLogger().info("Successfully Enabled HMCCosmetics");
         getInstance().getLogger().info(Cosmetics.values().size() + " Cosmetics Successfully Setup");
@@ -278,32 +272,5 @@ public final class HMCCosmeticsPlugin extends JavaPlugin {
     }
     public static String getLatestVersion() {
         return latestVersion;
-    }
-
-    private static void loadEmotes() {
-        File emoteDir = new File(getInstance().getDataFolder().getPath() + "/emotes/");
-        if (!emoteDir.exists()) return;
-
-        File[] emoteFiles = emoteDir.listFiles();
-        if (emoteFiles == null || emoteFiles.length == 0) return;
-
-        emoteFiles = Arrays.stream(emoteFiles).filter(file -> file.getPath().endsWith(".bbmodel")).distinct().toArray(File[]::new);
-        if (emoteFiles.length == 0) return;
-
-        for (File animationFile : emoteFiles) {
-            String animationKey = FilenameUtils.removeExtension(animationFile.getName());
-            PlayerAnimator.api.getAnimationManager().importAnimations(animationKey, animationFile);
-        }
-
-        for (Map.Entry<String, AnimationPack> packEntry : PlayerAnimator.api.getAnimationManager().getRegistry().entrySet()) {
-            packEntry.getValue().getAnimations().keySet().forEach(animation -> {
-                String key = packEntry.getKey().replace(":", ".") + "." + animation;
-                emoteMap.put(animation, key);
-            });
-        }
-    }
-
-    public static Map<String, String> getEmoteMap() {
-        return emoteMap;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
@@ -429,7 +429,7 @@ public class CosmeticCommand implements CommandExecutor {
                 }
 
                 if (args.length >= 2) {
-                    if (!PlayerAnimator.api.getAnimationManager().getRegistry().keySet().contains(args[1])) {
+                    if (!HMCCosmeticsPlugin.getEmoteMap().containsKey(args[1])) {
                         MessagesUtil.sendDebugMessages("Did not contain " + args[1]);
                         if (!silent) MessagesUtil.sendMessage(sender, "emote-invalid");
                         return true;
@@ -444,7 +444,7 @@ public class CosmeticCommand implements CommandExecutor {
                     return true;
                 }
                 CosmeticUser user = CosmeticUsers.getUser(player);
-                user.getUserEmoteManager().playEmote(args[1]);
+                user.getUserEmoteManager().playEmote(HMCCosmeticsPlugin.getEmoteMap().get(args[1]));
                 return true;
             }
         }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommand.java
@@ -8,6 +8,7 @@ import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetics;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticEmoteType;
 import com.hibiscusmc.hmccosmetics.database.Database;
+import com.hibiscusmc.hmccosmetics.emotes.EmoteManager;
 import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.gui.Menus;
 import com.hibiscusmc.hmccosmetics.gui.special.DyeMenu;
@@ -15,7 +16,6 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUsers;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import com.hibiscusmc.hmccosmetics.util.ServerUtils;
-import com.ticxo.playeranimator.api.PlayerAnimator;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.apache.commons.lang3.EnumUtils;
@@ -428,12 +428,10 @@ public class CosmeticCommand implements CommandExecutor {
                     return true;
                 }
 
-                if (args.length >= 2) {
-                    if (!HMCCosmeticsPlugin.getEmoteMap().containsKey(args[1])) {
-                        MessagesUtil.sendDebugMessages("Did not contain " + args[1]);
-                        if (!silent) MessagesUtil.sendMessage(sender, "emote-invalid");
-                        return true;
-                    }
+                if (!EmoteManager.has(args[1])) {
+                    MessagesUtil.sendDebugMessages("Did not contain " + args[1]);
+                    if (!silent) MessagesUtil.sendMessage(sender, "emote-invalid");
+                    return true;
                 }
 
                 if (sender.hasPermission("hmccosmetics.cmd.playemote.other")) {
@@ -444,7 +442,7 @@ public class CosmeticCommand implements CommandExecutor {
                     return true;
                 }
                 CosmeticUser user = CosmeticUsers.getUser(player);
-                user.getUserEmoteManager().playEmote(HMCCosmeticsPlugin.getEmoteMap().get(args[1]));
+                user.getUserEmoteManager().playEmote(EmoteManager.get(args[1]));
                 return true;
             }
         }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
@@ -1,9 +1,9 @@
 package com.hibiscusmc.hmccosmetics.command;
 
-import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetics;
+import com.hibiscusmc.hmccosmetics.emotes.EmoteManager;
 import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.gui.Menus;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
@@ -81,9 +81,7 @@ public class CosmeticCommandTabComplete implements TabCompleter {
                     completions.add("viewerlocation");
                     completions.add("leavelocation");
                 }
-                case "playemote" -> {
-                    completions.addAll(HMCCosmeticsPlugin.getEmoteMap().keySet());
-                }
+                case "playemote" -> completions.addAll(EmoteManager.getAllNames());
             }
             StringUtil.copyPartialMatches(args[1], completions, finalCompletions);
         }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/command/CosmeticCommandTabComplete.java
@@ -1,5 +1,6 @@
 package com.hibiscusmc.hmccosmetics.command;
 
+import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetics;
@@ -7,7 +8,6 @@ import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.gui.Menus;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUsers;
-import com.ticxo.playeranimator.api.PlayerAnimator;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -82,7 +82,7 @@ public class CosmeticCommandTabComplete implements TabCompleter {
                     completions.add("leavelocation");
                 }
                 case "playemote" -> {
-                    completions.addAll(PlayerAnimator.api.getAnimationManager().getRegistry().keySet());
+                    completions.addAll(HMCCosmeticsPlugin.getEmoteMap().keySet());
                 }
             }
             StringUtil.copyPartialMatches(args[1], completions, finalCompletions);

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/emotes/EmoteManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/emotes/EmoteManager.java
@@ -1,0 +1,85 @@
+package com.hibiscusmc.hmccosmetics.emotes;
+
+import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
+import com.ticxo.playeranimator.api.PlayerAnimator;
+import com.ticxo.playeranimator.api.animation.pack.AnimationPack;
+import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Manages Emotes
+ */
+@SuppressWarnings("SpellCheckingInspection")
+public class EmoteManager {
+    private static final @NotNull Map<@NotNull String, @NotNull String> emotes = new HashMap<>();
+
+    /**
+     * Loads all BlockBench animations from the emotes folder and puts it into the animation manager registry and local registry
+     */
+    public static void loadEmotes() {
+        // Clear the PlayerAnimator and local registries
+        PlayerAnimator.api.getAnimationManager().clearRegistry();
+        emotes.clear();
+
+        // Get the emote directory and check if it exists
+        File emoteDir = new File(HMCCosmeticsPlugin.getInstance().getDataFolder().getPath() + "/emotes/");
+        if (!emoteDir.exists()) return;
+
+        // Get all the files inside the directory and check if it isn't 0
+        File[] emoteFiles = emoteDir.listFiles();
+        if (emoteFiles == null || emoteFiles.length == 0) return;
+
+        // Remove any files that don't have the file extension ".bbmodel" and check if there are still resulting files
+        emoteFiles = Arrays.stream(emoteFiles).filter(file -> file.getPath().endsWith(".bbmodel")).distinct().toArray(File[]::new);
+        if (emoteFiles.length == 0) return;
+
+        // Loop through all files, importing all block bench animations into the registry
+        for (File animationFile : emoteFiles) {
+            String animationKey = FilenameUtils.removeExtension(animationFile.getName());
+            PlayerAnimator.api.getAnimationManager().importAnimations(animationKey, animationFile);
+        }
+
+        // Loops through all the entries in the registries and unpacks any animation packs to ensure if there were multiple animations
+        // inside a singular file, that they are added to the local registry individually for tab completion
+        for (Map.Entry<String, AnimationPack> packEntry : PlayerAnimator.api.getAnimationManager().getRegistry().entrySet()) {
+            packEntry.getValue().getAnimations().keySet().forEach(animationName -> {
+                // API key is the format "animationKey.animationFileName.animationName"
+                String apiKey = packEntry.getKey().replace(":", ".") + "." + animationName;
+                emotes.put(animationName, apiKey);
+            });
+        }
+    }
+
+    /**
+     * Returns true if there is an animation with the specified name
+     * @param animationName Name whose presence is to be tested
+     * @return True if this registry contains a mapping for the specified name
+     */
+    public static boolean has(@NotNull String animationName) {
+        return emotes.containsKey(animationName);
+    }
+
+    /**
+     * Returns the {@code API key} to which the specified name is mapped, or {@code null} if this map contains no mapping for the name.
+     * @param animationName Name whose {@code API key} is to be fetched
+     * @return The {@code API key} of the specified name or {@code null} if there was no animation name found
+     */
+    public static @Nullable String get(@NotNull String animationName) {
+        return emotes.get(animationName);
+    }
+
+    /**
+     * Gets a set of all the laoded animation names
+     * @return A set of all loaded animation names
+     */
+    public static @NotNull Set<String> getAllNames() {
+        return emotes.keySet();
+    }
+}


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [ ] Major breaking change
- [X] Minor change
- [X] Feature implementation
- [ ] Bug fix
- [ ] Chore (Changes that don't fix or add new features *and don't* modify source files)
- [ ] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [ ] Documentation (Changes to README files and/or JavaDocs)
- [ ] Style (Changes that don't affect the meaning of the code)
- [ ] Performance
- [ ] Other (Please specify below)

#### Please describe the changes this PR makes and why it should be merged:
This PR resolve #66

Let's see how the `AnimationManager` registry was populated beforehand.
https://github.com/HibiscusMC/HMCCosmetics/blob/f793f4e67aca99372b6bdecbec79d3b45661e950/common/src/main/java/com/hibiscusmc/hmccosmetics/HMCCosmeticsPlugin.java#L248-L253
As we can see, the code doesn't check if the `emoteFile`s `AnimationPack` has any unpacked `Animation`s inside of it. 

For example, if we had two files, one containing a singular animation where the other has a series of animations in a single file:
- Emote1.bbmodel
- EmotePack.bbmodel
  - Emote2
  - Emote3
  - Emote4
The old system would treat the only emotes as `Emote1` and `EmotePack`, when `EmotePack` isn't even an emote. This is what the new emote loading system strives to fix.

---


The new emote loading system fixes the problems above by looping through the `AnimationManager.getRegistry` and unpacking all `AnimationPack`s to see if they have more than one `Animation` in it.

```java
for (Map.Entry<String, AnimationPack> packEntry : PlayerAnimator.api.getAnimationManager().getRegistry().entrySet()) {
    packEntry.getValue().getAnimations().keySet().forEach(animation -> {
        String key = packEntry.getKey().replace(":", ".") + "." + animation;
        emoteMap.put(animation, key);
    });
}
```

#### Check that:
- [X] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [X] Syntax and style are consistent with existing code
- [X] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
