### PR TITLE
Fixed interaction between backpack cosmetics and other passengers

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
@@ -45,8 +45,6 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.spigotmc.event.entity.EntityDismountEvent;
-import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.util.*;
 
@@ -359,24 +357,6 @@ public class PlayerGameListener implements Listener {
             user.getBalloonManager().getModelEntity().teleport(NPCLocation.add(Settings.getBalloonOffset()));
         }
     }
-
-    @EventHandler
-	public void onPlayerMounted(EntityMountEvent event) {
-		if (!event.isCancelled() && event.getMount() instanceof Player player) {
-            CosmeticUser user = CosmeticUsers.getUser(player);
-            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(HMCCosmeticsPlugin.getInstance(), ()->{
-                user.getUserBackpackManager().reattach();
-            }, 1);
-		}
-	}
-
-	@EventHandler
-	public void onPlayerDismounted(EntityDismountEvent event) {
-		if (!event.isCancelled() && event.getDismounted() instanceof Player player) {
-            CosmeticUser user = CosmeticUsers.getUser(player);
-            user.getUserBackpackManager().reattach();
-		}
-	}
 
     private void registerInventoryClickListener() {
         ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(HMCCosmeticsPlugin.getInstance(), ListenerPriority.NORMAL, PacketType.Play.Client.WINDOW_CLICK) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
@@ -45,6 +45,8 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.util.*;
 
@@ -357,6 +359,24 @@ public class PlayerGameListener implements Listener {
             user.getBalloonManager().getModelEntity().teleport(NPCLocation.add(Settings.getBalloonOffset()));
         }
     }
+
+    @EventHandler
+	public void onPlayerMounted(EntityMountEvent event) {
+		if (!event.isCancelled() && event.getMount() instanceof Player player) {
+            CosmeticUser user = CosmeticUsers.getUser(player);
+            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(HMCCosmeticsPlugin.getInstance(), ()->{
+                user.getUserBackpackManager().reattach();
+            }, 1);
+		}
+	}
+
+	@EventHandler
+	public void onPlayerDismounted(EntityDismountEvent event) {
+		if (!event.isCancelled() && event.getDismounted() instanceof Player player) {
+            CosmeticUser user = CosmeticUsers.getUser(player);
+            user.getUserBackpackManager().reattach();
+		}
+	}
 
     private void registerInventoryClickListener() {
         ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(HMCCosmeticsPlugin.getInstance(), ListenerPriority.NORMAL, PacketType.Play.Client.WINDOW_CLICK) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
@@ -45,6 +45,8 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
 
 import java.util.*;
 
@@ -357,6 +359,30 @@ public class PlayerGameListener implements Listener {
             user.getBalloonManager().getModelEntity().teleport(NPCLocation.add(Settings.getBalloonOffset()));
         }
     }
+
+    @EventHandler
+	public void onPlayerMounted(EntityMountEvent event) {
+		if (!event.isCancelled() && event.getEntity() instanceof Player player) {
+            CosmeticUser user = CosmeticUsers.getUser(player);
+            if (user == null) return;
+
+            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(HMCCosmeticsPlugin.getInstance(), ()->{
+                user.respawnBackpack();
+            }, 1);
+		}
+	}
+
+	@EventHandler
+	public void onPlayerDismounted(EntityDismountEvent event) {
+		if (!event.isCancelled() && event.getDismounted() instanceof Player player) {
+            CosmeticUser user = CosmeticUsers.getUser(player);
+            if (user == null) return;
+
+            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(HMCCosmeticsPlugin.getInstance(), ()->{
+                user.respawnBackpack();
+            }, 1);
+		}
+	}
 
     private void registerInventoryClickListener() {
         ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(HMCCosmeticsPlugin.getInstance(), ListenerPriority.NORMAL, PacketType.Play.Client.WINDOW_CLICK) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
@@ -1,6 +1,5 @@
 package com.hibiscusmc.hmccosmetics.user.manager;
 
-import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticBackpackType;
 import com.hibiscusmc.hmccosmetics.hooks.Hooks;
@@ -11,8 +10,6 @@ import com.hibiscusmc.hmccosmetics.util.packets.PacketManager;
 import com.ticxo.modelengine.api.ModelEngineAPI;
 import com.ticxo.modelengine.api.model.ActiveModel;
 import com.ticxo.modelengine.api.model.ModeledEntity;
-
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
@@ -67,26 +64,6 @@ public class UserBackpackManager {
 
     private void spawn(CosmeticBackpackType cosmeticBackpackType) {
         if (this.invisibleArmorStand != null) return;
-
-        attach(cosmeticBackpackType);
-
-        // No one should be using ME because it barely works but some still use it, so it's here
-        if (cosmeticBackpackType.getModelName() != null && Hooks.isActiveHook("ModelEngine")) {
-            if (ModelEngineAPI.api.getModelRegistry().getBlueprint(cosmeticBackpackType.getModelName()) == null) {
-                MessagesUtil.sendDebugMessages("Invalid Model Engine Blueprint " + cosmeticBackpackType.getModelName(), Level.SEVERE);
-                return;
-            }
-            ModeledEntity modeledEntity = ModelEngineAPI.getOrCreateModeledEntity(invisibleArmorStand);
-            ActiveModel model = ModelEngineAPI.createActiveModel(ModelEngineAPI.getBlueprint(cosmeticBackpackType.getModelName()));
-            model.setCanHurt(false);
-            modeledEntity.addModel(model, false);
-        }
-
-        MessagesUtil.sendDebugMessages("spawnBackpack Bukkit - Finish");
-    }
-
-    private void attach(CosmeticBackpackType cosmeticBackpackType) {
-        if (this.invisibleArmorStand != null) return;
         this.invisibleArmorStand = (ArmorStand) NMSHandlers.getHandler().spawnBackpack(user, cosmeticBackpackType);
 
         List<Player> outsideViewers = user.getUserBackpackManager().getCloudManager().refreshViewers(user.getEntity().getLocation());
@@ -112,10 +89,20 @@ public class UserBackpackManager {
             if (!user.getHidden()) NMSHandlers.getHandler().equipmentSlotUpdate(user.getUserBackpackManager().getFirstArmorStandId(), EquipmentSlot.HEAD, cosmeticBackpackType.getFirstPersonBackpack(), owner);
         }
         PacketManager.sendRidingPacket(entity.getEntityId(), user.getUserBackpackManager().getFirstArmorStandId(), outsideViewers);
-    }
 
-    public void reattach() {
-        attach((CosmeticBackpackType) user.getCosmetic(CosmeticSlot.BACKPACK));
+        // No one should be using ME because it barely works but some still use it, so it's here
+        if (cosmeticBackpackType.getModelName() != null && Hooks.isActiveHook("ModelEngine")) {
+            if (ModelEngineAPI.api.getModelRegistry().getBlueprint(cosmeticBackpackType.getModelName()) == null) {
+                MessagesUtil.sendDebugMessages("Invalid Model Engine Blueprint " + cosmeticBackpackType.getModelName(), Level.SEVERE);
+                return;
+            }
+            ModeledEntity modeledEntity = ModelEngineAPI.getOrCreateModeledEntity(invisibleArmorStand);
+            ActiveModel model = ModelEngineAPI.createActiveModel(ModelEngineAPI.getBlueprint(cosmeticBackpackType.getModelName()));
+            model.setCanHurt(false);
+            modeledEntity.addModel(model, false);
+        }
+
+        MessagesUtil.sendDebugMessages("spawnBackpack Bukkit - Finish");
     }
 
     public void despawnBackpack() {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
@@ -66,12 +66,21 @@ public class UserBackpackManager {
         if (this.invisibleArmorStand != null) return;
         this.invisibleArmorStand = (ArmorStand) NMSHandlers.getHandler().spawnBackpack(user, cosmeticBackpackType);
 
+        Entity entity = user.getEntity();
+
+        int[] passengerIDs = new int[entity.getPassengers().size() + 1];
+
+        for (int i = 0; i < entity.getPassengers().size(); i++) {
+            passengerIDs[i] = entity.getPassengers().get(i).getEntityId();
+        }
+
+        passengerIDs[passengerIDs.length - 1] = this.getFirstArmorStandId();
+
         List<Player> outsideViewers = user.getUserBackpackManager().getCloudManager().refreshViewers(user.getEntity().getLocation());
-        PacketManager.sendRidingPacket(user.getEntity().getEntityId(), user.getUserBackpackManager().getFirstArmorStandId(), outsideViewers);
+        PacketManager.sendRidingPacket(user.getEntity().getEntityId(), passengerIDs, outsideViewers);
 
         ArrayList<Player> owner = new ArrayList<>();
         if (user.getPlayer() != null) owner.add(user.getPlayer());
-        Entity entity = user.getEntity();
 
         if (cosmeticBackpackType.isFirstPersonCompadible()) {
             for (int i = particleCloud.size(); i < 5; i++) {
@@ -88,7 +97,7 @@ public class UserBackpackManager {
             PacketManager.sendRidingPacket(particleCloud.get(particleCloud.size() - 1), user.getUserBackpackManager().getFirstArmorStandId(), owner);
             if (!user.getHidden()) NMSHandlers.getHandler().equipmentSlotUpdate(user.getUserBackpackManager().getFirstArmorStandId(), EquipmentSlot.HEAD, cosmeticBackpackType.getFirstPersonBackpack(), owner);
         }
-        PacketManager.sendRidingPacket(entity.getEntityId(), user.getUserBackpackManager().getFirstArmorStandId(), outsideViewers);
+        PacketManager.sendRidingPacket(entity.getEntityId(), passengerIDs, outsideViewers);
 
         // No one should be using ME because it barely works but some still use it, so it's here
         if (cosmeticBackpackType.getModelName() != null && Hooks.isActiveHook("ModelEngine")) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserBackpackManager.java
@@ -1,5 +1,6 @@
 package com.hibiscusmc.hmccosmetics.user.manager;
 
+import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticBackpackType;
 import com.hibiscusmc.hmccosmetics.hooks.Hooks;
@@ -10,6 +11,8 @@ import com.hibiscusmc.hmccosmetics.util.packets.PacketManager;
 import com.ticxo.modelengine.api.ModelEngineAPI;
 import com.ticxo.modelengine.api.model.ActiveModel;
 import com.ticxo.modelengine.api.model.ModeledEntity;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
@@ -64,6 +67,26 @@ public class UserBackpackManager {
 
     private void spawn(CosmeticBackpackType cosmeticBackpackType) {
         if (this.invisibleArmorStand != null) return;
+
+        attach(cosmeticBackpackType);
+
+        // No one should be using ME because it barely works but some still use it, so it's here
+        if (cosmeticBackpackType.getModelName() != null && Hooks.isActiveHook("ModelEngine")) {
+            if (ModelEngineAPI.api.getModelRegistry().getBlueprint(cosmeticBackpackType.getModelName()) == null) {
+                MessagesUtil.sendDebugMessages("Invalid Model Engine Blueprint " + cosmeticBackpackType.getModelName(), Level.SEVERE);
+                return;
+            }
+            ModeledEntity modeledEntity = ModelEngineAPI.getOrCreateModeledEntity(invisibleArmorStand);
+            ActiveModel model = ModelEngineAPI.createActiveModel(ModelEngineAPI.getBlueprint(cosmeticBackpackType.getModelName()));
+            model.setCanHurt(false);
+            modeledEntity.addModel(model, false);
+        }
+
+        MessagesUtil.sendDebugMessages("spawnBackpack Bukkit - Finish");
+    }
+
+    private void attach(CosmeticBackpackType cosmeticBackpackType) {
+        if (this.invisibleArmorStand != null) return;
         this.invisibleArmorStand = (ArmorStand) NMSHandlers.getHandler().spawnBackpack(user, cosmeticBackpackType);
 
         List<Player> outsideViewers = user.getUserBackpackManager().getCloudManager().refreshViewers(user.getEntity().getLocation());
@@ -89,20 +112,10 @@ public class UserBackpackManager {
             if (!user.getHidden()) NMSHandlers.getHandler().equipmentSlotUpdate(user.getUserBackpackManager().getFirstArmorStandId(), EquipmentSlot.HEAD, cosmeticBackpackType.getFirstPersonBackpack(), owner);
         }
         PacketManager.sendRidingPacket(entity.getEntityId(), user.getUserBackpackManager().getFirstArmorStandId(), outsideViewers);
+    }
 
-        // No one should be using ME because it barely works but some still use it, so it's here
-        if (cosmeticBackpackType.getModelName() != null && Hooks.isActiveHook("ModelEngine")) {
-            if (ModelEngineAPI.api.getModelRegistry().getBlueprint(cosmeticBackpackType.getModelName()) == null) {
-                MessagesUtil.sendDebugMessages("Invalid Model Engine Blueprint " + cosmeticBackpackType.getModelName(), Level.SEVERE);
-                return;
-            }
-            ModeledEntity modeledEntity = ModelEngineAPI.getOrCreateModeledEntity(invisibleArmorStand);
-            ActiveModel model = ModelEngineAPI.createActiveModel(ModelEngineAPI.getBlueprint(cosmeticBackpackType.getModelName()));
-            model.setCanHurt(false);
-            modeledEntity.addModel(model, false);
-        }
-
-        MessagesUtil.sendDebugMessages("spawnBackpack Bukkit - Finish");
+    public void reattach() {
+        attach((CosmeticBackpackType) user.getCosmetic(CosmeticSlot.BACKPACK));
     }
 
     public void despawnBackpack() {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/PacketManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/PacketManager.java
@@ -252,7 +252,26 @@ public class PacketManager extends BasePacket {
 
     /**
      * Mostly to deal with backpacks, this deals with entities riding other entities.
-     * @param mountId The entity that is the "mount", ex. a player
+     * @param mountIds The entity that is the "mount", ex. a player
+     * @param passengerIds The entities that are riding the mount, ex. a armorstand for a backpack
+     * @param sendTo Whom to send the packet to
+     */
+    public static void sendRidingPacket(
+            final int mountId,
+            final int[] passengerIds,
+            final @NotNull List<Player> sendTo
+    ) {
+        PacketContainer packet = new PacketContainer(PacketType.Play.Server.MOUNT);
+        packet.getIntegers().write(0, mountId);
+        packet.getIntegerArrays().write(0, passengerIds);
+        for (final Player p : sendTo) {
+            sendPacket(p, packet);
+        }
+    }
+
+    /**
+     * Mostly to deal with backpacks, this deals with entities riding other entities.
+     * @param mountIds The entity that is the "mount", ex. a player
      * @param passengerId The entity that is riding the mount, ex. a armorstand for a backpack
      * @param sendTo Whom to send the packet to
      */
@@ -261,12 +280,7 @@ public class PacketManager extends BasePacket {
             final int passengerId,
             final @NotNull List<Player> sendTo
     ) {
-        PacketContainer packet = new PacketContainer(PacketType.Play.Server.MOUNT);
-        packet.getIntegers().write(0, mountId);
-        packet.getIntegerArrays().write(0, new int[]{passengerId});
-        for (final Player p : sendTo) {
-            sendPacket(p, packet);
-        }
+        sendRidingPacket(mountId, new int[] {passengerId}, sendTo);
     }
 
     /**

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/PacketManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/packets/PacketManager.java
@@ -252,7 +252,7 @@ public class PacketManager extends BasePacket {
 
     /**
      * Mostly to deal with backpacks, this deals with entities riding other entities.
-     * @param mountIds The entity that is the "mount", ex. a player
+     * @param mountId The entity that is the "mount", ex. a player
      * @param passengerIds The entities that are riding the mount, ex. a armorstand for a backpack
      * @param sendTo Whom to send the packet to
      */
@@ -271,7 +271,7 @@ public class PacketManager extends BasePacket {
 
     /**
      * Mostly to deal with backpacks, this deals with entities riding other entities.
-     * @param mountIds The entity that is the "mount", ex. a player
+     * @param mountId The entity that is the "mount", ex. a player
      * @param passengerId The entity that is riding the mount, ex. a armorstand for a backpack
      * @param sendTo Whom to send the packet to
      */


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [ ] Major breaking change
- [ ] Minor change
- [ ] Feature implementation
- [X ] Bug fix
- [ ] Chore (Changes that don't fix or add new features *and don't* modify source files)
- [ ] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [ ] Documentation (Changes to README files and/or JavaDocs)
- [ ] Style (Changes that don't affect the meaning of the code)
- [ ] Performance
- [ ] Other (Please specify below)

#### Please describe the changes this PR makes and why it should be merged:
* When spawning a backpack, add the entity ID's of all currently riding entities to the riding packet. This will prevent the back cosmetic from dismounting all current riders
* When the player is mounted or dismounted, respawn the player's backpack to ensure that it doesn't fall off

#### Check that:
- [X ] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [X ] Syntax and style are consistent with existing code
- [X ] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
