### PR TITLE
refactor: make hidden-cosmetics message only show when player has cos…

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -71,7 +71,7 @@ public class CosmeticUser {
         Runnable run = () -> {
             MessagesUtil.sendDebugMessages("Tick[uuid=" + uniqueId + "]", Level.INFO);
             updateCosmetic();
-            if (isHidden() && !getUserEmoteManager().isPlayingEmote()) MessagesUtil.sendActionBar(getPlayer(), "hidden-cosmetics");
+            if (isHidden() && !getUserEmoteManager().isPlayingEmote() && !getCosmetics().isEmpty()) MessagesUtil.sendActionBar(getPlayer(), "hidden-cosmetics");
         };
 
         int tickPeriod = Settings.getTickPeriod();


### PR DESCRIPTION
got too annoyed at this permanently being on my screen
think making it either only show when cosmetics are equipped or just flash ones is the better approach

![image](https://github.com/HibiscusMC/HMCCosmetics/assets/62521371/5978b44b-153b-427d-b486-2e4d001c40de)
