### PR TITLE
`HMCCosmeticsAPI` Javadoc Changes

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
@@ -17,122 +17,149 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * The main API class for HMCCosmetics. This class provides methods to interact with the plugin.
+ */
 public class HMCCosmeticsAPI {
 
     /**
-     * Attempts to get a cosmetic from HMCCosmetics
-     *
-     * @param cosmetic Cosmetic Id
-     * @return A {@link Cosmetic} if exists or null if it does not
+     * Retrieves a {@link Cosmetic} associated with the specified id.
+     * <p>
+     * This method attempts to fetch a {@link Cosmetic} using the given id. If no {@link Cosmetic} exists
+     * with the specified id, it will return {@code null}.
+     * </p>
+     * @param id the id of the {@link Cosmetic} to retrieve; must not be {@code null}
+     * @return the {@link Cosmetic} if it exists, or {@code null} if no cosmetic is associated with the given id
      */
-    @Nullable
-    public static Cosmetic getCosmetic(@NotNull String cosmetic) {
-        return Cosmetics.getCosmetic(cosmetic);
+    public static @Nullable Cosmetic getCosmetic(@NotNull String id) {
+        return Cosmetics.getCosmetic(id);
     }
 
     /**
-     * Attempts to get the CosmeticUser from an online user. If a player is offline it will return null.
-     * A player maybe online but not have a CosmeticUser attached to them, either from delay specified in the config
-     * or from a /reload. Always check if it's null!
+     * Retrieves the {@link CosmeticUser} associated with the specified player's {@link UUID}.
+     * <p>
+     * This method attempts to fetch a {@link CosmeticUser} for an online player. If the player is offline,
+     * or if no {@link CosmeticUser} is currently associated with them, it will return {@code null}.
+     * </p>
+     * Note that a player may be online but not have a {@link CosmeticUser} attached due to:
+     * <ul>
+     *   <li>A delay specified in the configuration</li>
+     *   <li>A recent server reload (e.g., via the {@code /reload} command)</li>
+     * </ul>
+     * Always perform a {@code null} check before using the returned object to ensure safe operation.
      *
-     * @param uuid Player Unique ID
-     * @return A {@link CosmeticUser} if exists or null if it does not
+     * @param uuid the {@link UUID} of the player whose {@link CosmeticUser} is being retrieved; must not be {@code null}
+     * @return the {@link CosmeticUser} if it exists, or {@code null} if the player is offline or unassociated
      */
-    @Nullable
-    public static CosmeticUser getUser(@NotNull UUID uuid) {
+    public static @Nullable CosmeticUser getUser(@NotNull UUID uuid) {
         return CosmeticUsers.getUser(uuid);
     }
 
     /**
-     * Attempts to get a HMCCosmetics Menu. Returns null if no menu exists under that id.
+     * Retrieves a {@link Menu} associated with the specified id, or {@code null} if no menu exists with the given id.
      *
-     * @param id Menu ID
-     * @return A {@link Menu} if exists or null if it does not
+     * @param id the id of the menu to retrieve; must not be {@code null}
+     * @return the {@link Menu} if it exists, or {@code null} if no menu is associated with the given id
      */
-    @Nullable
-    public static Menu getMenu(@NotNull String id) {
+    public static @Nullable Menu getMenu(@NotNull String id) {
         return Menus.getMenu(id);
     }
 
     /**
-     * Equips a cosmetic to a player. You can use getUser and getCosmetic to get the CosmeticUser and Cosmetic to equip.
-     * @param user CosmeticUser to equip cosmetic to
-     * @param cosmetic Cosmetic to equip
+     * Equips a {@link Cosmetic} to a player. To retrieve the necessary {@code CosmeticUser} and {@code Cosmetic}, use the {@link #getUser}
+     * and {@link #getCosmetic} methods respectively.
+     *
+     * @param user the {@link CosmeticUser} to equip the cosmetic to
+     * @param cosmetic the {@link Cosmetic} to equip
      */
     public static void equipCosmetic(@NotNull CosmeticUser user, @NotNull Cosmetic cosmetic) {
         equipCosmetic(user, cosmetic, null);
     }
 
     /**
-     * Equips a cosmetic to a player with a color. You can use getUser and getCosmetic to get the CosmeticUser and Cosmetic to equip.
-     * @param user CosmeticUser to equip cosmetic to
-     * @param cosmetic Cosmetic to equip
-     * @param color Color to apply to cosmetic
+     * Equips a {@link Cosmetic} to a player with an optional color customization. To retrieve the necessary
+     * {@code CosmeticUser} and {@code Cosmetic}, use the {@link #getUser} and {@link #getCosmetic} methods
+     * respectively.
+     *
+     * @param user the {@link CosmeticUser} to equip the cosmetic to
+     * @param cosmetic the {@link Cosmetic} to equip
+     * @param color the color to apply to the cosmetic, or {@code null} if the cosmetic does not support color
+     *              customization
      */
     public static void equipCosmetic(@NotNull CosmeticUser user, @NotNull Cosmetic cosmetic, @Nullable Color color) {
         user.addPlayerCosmetic(cosmetic, color);
     }
 
     /**
-     * Removes a cosmetic in cosmeticslot.
-     * @param user The user to remove the cosmetic from
-     * @param slot The slot to remove the cosmetic from
+     * Removes a cosmetic from a specified slot for the given user.
+     *
+     * @param user the {@link CosmeticUser} from whom the cosmetic will be removed
+     * @param slot the {@link CosmeticSlot} from which the cosmetic will be removed
      */
     public static void unequipCosmetic(@NotNull CosmeticUser user, @NotNull CosmeticSlot slot) {
         user.removeCosmeticSlot(slot);
     }
 
     /**
-     * Gets all Cosmetics that are currently registered with HMCC. This list is immutable!
-     * @return A list of all registered cosmetics
+     * Retrieves a list of all cosmetics currently registered with HMCC.
+     *
+     * @return an {@code immutable} list containing all registered {@link Cosmetic} object
      */
-    @NotNull
-    public static List<Cosmetic> getAllCosmetics() {
+    public static @NotNull List<Cosmetic> getAllCosmetics() {
         return List.copyOf(Cosmetics.values());
     }
 
     /**
-     * Gets all CosmeticUsers that are currently registered with HMCC. This list is immutable!
-     * @return A list of all registered CosmeticUsers
+     * Retrieves a list of all cosmetic users currently registered with HMCC.
+     *
+     * @return an immutable list containing all registered {@link CosmeticUser} objects
      */
-    @NotNull
-    public static List<CosmeticUser> getAllCosmeticUsers() {
+    public static @NotNull List<CosmeticUser> getAllCosmeticUsers() {
         return List.copyOf(CosmeticUsers.values());
     }
 
     /**
-     * Gets all the cosmetic slots that are registered with HMCC. This map is immutable!
-     * @return A map of all registered cosmetic slots
+     * Retrieves a map of all cosmetic slots currently registered with HMCC.
+     *
+     * @return an immutable {@link Map} containing all registered cosmetic slots
      */
-    @NotNull
-    public static Map<String, CosmeticSlot> getAllCosmeticSlots() {
+    public static @NotNull Map<String, CosmeticSlot> getAllCosmeticSlots() {
         return Map.copyOf(CosmeticSlot.values());
     }
 
     /**
-     * Registers a new cosmetic slot with the given id. If a slot with the given id already exists, it will be returned.
-     * @param id The id of the slot, this will automatically be converted to all UPPERCASE when registering the slot
+     * Registers a new cosmetic slot with the specified id. If a slot with the same id already exists,
+     * the existing slot will be returned.
+     *
+     * <p>
+     *     The provided id will automatically be converted to uppercase when registering the slot.
+     * </p>
+     *
+     * @param id the id for the cosmetic slot
+     * @return the {@link CosmeticSlot} associated with the given ID
      */
-    @NotNull
-    public static CosmeticSlot registerCosmeticSlot(@NotNull String id) {
+    public static @NotNull CosmeticSlot registerCosmeticSlot(@NotNull String id) {
         return CosmeticSlot.register(id);
     }
 
     /**
-     * This returns the NMS version of the server as recognized by HMCCosmetics. This will be null until HMCC setup has been completed.
-     * @return The NMS version of the server in String format
+     * Retrieves the NMS version of the server as recognized by HMCCosmetics.
+     *
+     * <p>This value will be {@code null} until the HMCC setup has been completed. Ensure setup is finished
+     * before attempting to access this version.</p>
+     *
+     * @return the NMS version of the server in string format, or {@code null} if setup is not complete.
      */
-    @Nullable
-    public static String getNMSVersion() {
+    public static @Nullable String getNMSVersion() {
         return NMSHandlers.getVersion();
     }
 
     /**
-     * This returns the HMCCosmetics version.
-     * @return The HMCCosmetics version in String format
+     * Retrieves the version of HMCCosmetics currently in use.
+     *
+     * @return the HMCCosmetics version in string format
      */
-    @NotNull
-    public static String getHMCCVersion() {
+    public static @NotNull String getHMCCVersion() {
         return HMCCosmeticsPlugin.getInstance().getDescription().getVersion();
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
@@ -20,7 +20,10 @@ import java.util.UUID;
 /**
  * The main API class for HMCCosmetics. This class provides methods to interact with the plugin.
  */
-public class HMCCosmeticsAPI {
+public final class HMCCosmeticsAPI {
+    private HMCCosmeticsAPI() {
+        throw new UnsupportedOperationException("This class cannot be instantiated.");
+    }
 
     /**
      * Retrieves a {@link Cosmetic} associated with the specified id.


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [ ] Major breaking change
- [x] Minor change
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Chore (Changes that don't fix or add new features *and don't* modify source files)
- [x] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [x] Documentation (Changes to README files and/or JavaDocs)
- [x] Style (Changes that don't affect the meaning of the code)
- [ ] Performance
- [ ] Other (Please specify below)

#### Please describe the changes this PR makes and why it should be merged:
Marked `HMCCosmeticsAPI` as `final` to prevent extension and added a private constructor to prevent instantiation. Also improved upon Javadocs on most methods, retaining the original meaning but improving clarity.


#### Check that:
- [x] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [x] Syntax and style are consistent with existing code
- [x] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
