### PR TITLE
fix recursive registration

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/CosmeticSlot.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/cosmetic/CosmeticSlot.java
@@ -10,22 +10,21 @@ import java.util.concurrent.ConcurrentHashMap;
 public class CosmeticSlot {
     private static final ConcurrentHashMap<String, CosmeticSlot> REGISTRY = new ConcurrentHashMap<>();
 
-    public static final CosmeticSlot HELMET = new CosmeticSlot("HELMET");
-    public static final CosmeticSlot CHESTPLATE = new CosmeticSlot("CHESTPLATE");
-    public static final CosmeticSlot LEGGINGS = new CosmeticSlot("LEGGINGS");
-    public static final CosmeticSlot BOOTS = new CosmeticSlot("BOOTS");
-    public static final CosmeticSlot MAINHAND = new CosmeticSlot("MAINHAND");
-    public static final CosmeticSlot OFFHAND = new CosmeticSlot("OFFHAND");
-    public static final CosmeticSlot BACKPACK = new CosmeticSlot("BACKPACK");
-    public static final CosmeticSlot BALLOON = new CosmeticSlot("BALLOON");
-    public static final CosmeticSlot EMOTE = new CosmeticSlot("EMOTE");
-    public static final CosmeticSlot CUSTOM = new CosmeticSlot("CUSTOM");
+    public static final CosmeticSlot HELMET = register("HELMET");
+    public static final CosmeticSlot CHESTPLATE = register("CHESTPLATE");
+    public static final CosmeticSlot LEGGINGS = register("LEGGINGS");
+    public static final CosmeticSlot BOOTS = register("BOOTS");
+    public static final CosmeticSlot MAINHAND = register("MAINHAND");
+    public static final CosmeticSlot OFFHAND = register("OFFHAND");
+    public static final CosmeticSlot BACKPACK = register("BACKPACK");
+    public static final CosmeticSlot BALLOON = register("BALLOON");
+    public static final CosmeticSlot EMOTE = register("EMOTE");
+    public static final CosmeticSlot CUSTOM = register("CUSTOM");
 
     private final String name;
 
     private CosmeticSlot(@NotNull String name) {
         this.name = name;
-        REGISTRY.put(name, this);
     }
 
     /**


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [X] Bug fix

#### Please describe the changes this PR makes and why it should be merged:
Fixes a case of API Usage where attempting to register a custom slot via `CosmeticSlot#register` would recursively cycle in the registry due to the constructor also accessing the registry.

#### Check that:
- [x] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [x] Syntax and style are consistent with existing code
- [x] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
