### PR TITLE
Implement Custom Player Providers

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
@@ -7,9 +7,12 @@ import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetics;
 import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.gui.Menus;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
+import com.hibiscusmc.hmccosmetics.user.CosmeticUserProvider;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUsers;
+import lombok.Getter;
 import me.lojosho.hibiscuscommons.nms.NMSHandlers;
 import org.bukkit.Color;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -143,6 +146,16 @@ public final class HMCCosmeticsAPI {
      */
     public static @NotNull CosmeticSlot registerCosmeticSlot(@NotNull String id) {
         return CosmeticSlot.register(id);
+    }
+
+    /**
+     * Registers a new cosmetic user provider to use to construct {@link CosmeticUser}s.
+     *
+     * @param provider the provider to register
+     * @throws IllegalArgumentException if another plugin has already registered a provider
+     */
+    public static void registerCosmeticUserProvider(final CosmeticUserProvider provider) {
+        CosmeticUsers.registerProvider(provider);
     }
 
     /**

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/HMCCosmeticsAPI.java
@@ -159,6 +159,15 @@ public final class HMCCosmeticsAPI {
     }
 
     /**
+     * Fetch the current {@link CosmeticUserProvider} that is in use.
+     *
+     * @return the {@link CosmeticUserProvider}
+     */
+    public static CosmeticUserProvider getCosmeticUserProvider() {
+        return CosmeticUsers.getProvider();
+    }
+
+    /**
      * Retrieves the NMS version of the server as recognized by HMCCosmetics.
      *
      * <p>This value will be {@code null} until the HMCC setup has been completed. Ensure setup is finished

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUserProvider.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUserProvider.java
@@ -1,0 +1,43 @@
+package com.hibiscusmc.hmccosmetics.user;
+
+import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
+import com.hibiscusmc.hmccosmetics.database.UserData;
+import org.bukkit.plugin.Plugin;
+
+import java.util.UUID;
+
+/**
+ * Allow custom implementations of a {@link CosmeticUser}.
+ */
+public interface CosmeticUserProvider {
+    CosmeticUserProvider DEFAULT = new Default();
+
+    /**
+     * Construct the custom {@link CosmeticUser}.
+     * @param playerId the player uuid
+     * @param userData the user data associated with the player
+     * @return the {@link CosmeticUser}
+     */
+    CosmeticUser createCosmeticUser(UUID playerId, UserData userData);
+
+    /**
+     * Represents the plugin that is providing this {@link CosmeticUserProvider}
+     * @return the plugin
+     */
+    Plugin getProviderPlugin();
+
+    /**
+     * Default implementation.
+     */
+    class Default implements CosmeticUserProvider {
+        @Override
+        public CosmeticUser createCosmeticUser(UUID playerId, UserData userData) {
+            return new CosmeticUser(playerId, userData);
+        }
+
+        @Override
+        public Plugin getProviderPlugin() {
+            return HMCCosmeticsPlugin.getInstance();
+        }
+    }
+}

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUserProvider.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUserProvider.java
@@ -21,6 +21,13 @@ public interface CosmeticUserProvider {
     CosmeticUser createCosmeticUser(UUID playerId, UserData userData);
 
     /**
+     * Construct the custom {@link CosmeticUser}.
+     * @param playerId the player uuid
+     * @return the {@link CosmeticUser}
+     */
+    CosmeticUser createCosmeticUserWithoutData(UUID playerId);
+
+    /**
      * Represents the plugin that is providing this {@link CosmeticUserProvider}
      * @return the plugin
      */
@@ -33,6 +40,11 @@ public interface CosmeticUserProvider {
         @Override
         public CosmeticUser createCosmeticUser(UUID playerId, UserData userData) {
             return new CosmeticUser(playerId, userData);
+        }
+
+        @Override
+        public CosmeticUser createCosmeticUserWithoutData(UUID playerId) {
+            return new CosmeticUser(playerId);
         }
 
         @Override

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUsers.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUsers.java
@@ -81,7 +81,7 @@ public class CosmeticUsers {
      * @throws IllegalArgumentException if the provider is already registered by another plugin
      */
     public static void registerProvider(final CosmeticUserProvider provider) {
-        if(provider != CosmeticUserProvider.DEFAULT) {
+        if(PROVIDER != CosmeticUserProvider.DEFAULT) {
             throw new IllegalArgumentException("CosmeticUserProvider already registered by %s, this conflicts with %s attempting to register their own.".formatted(
                 PROVIDER.getProviderPlugin().getName(),
                 provider.getProviderPlugin().getName()

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUsers.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUsers.java
@@ -2,6 +2,7 @@ package com.hibiscusmc.hmccosmetics.user;
 
 import com.google.common.collect.HashBiMap;
 import com.hibiscusmc.hmccosmetics.util.HMCCServerUtils;
+import lombok.Getter;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -11,8 +12,9 @@ import java.util.Set;
 import java.util.UUID;
 
 public class CosmeticUsers {
-
     private static final HashBiMap<UUID, CosmeticUser> COSMETIC_USERS = HashBiMap.create();
+
+    private static CosmeticUserProvider PROVIDER = CosmeticUserProvider.DEFAULT;
 
     /**
      * Adds a user to the Hashmap of stored CosmeticUsers. This will not override an entry if it already exists. If you need to override, delete then add.
@@ -70,6 +72,31 @@ public class CosmeticUsers {
         if (entity == null) return null;
         if (!(entity instanceof Player player)) return null;
         return COSMETIC_USERS.get(player.getUniqueId());
+    }
+
+    /**
+     * Register a custom {@link CosmeticUserProvider} to provide your own user implementation to
+     * be used and queried.
+     * @param provider the provider to register
+     * @throws IllegalArgumentException if the provider is already registered by another plugin
+     */
+    public static void registerProvider(final CosmeticUserProvider provider) {
+        if(provider != CosmeticUserProvider.DEFAULT) {
+            throw new IllegalArgumentException("CosmeticUserProvider already registered by %s, this conflicts with %s attempting to register their own.".formatted(
+                PROVIDER.getProviderPlugin().getName(),
+                provider.getProviderPlugin().getName()
+            ));
+        }
+
+        PROVIDER = provider;
+    }
+
+    /**
+     * Fetch the current {@link CosmeticUserProvider} being used.
+     * @return the current {@link CosmeticUserProvider} being used
+     */
+    public static CosmeticUserProvider getProvider() {
+        return PROVIDER;
     }
 
     /**


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [X] Feature implementation

#### Please describe the changes this PR makes and why it should be merged:
Allows for addons to register their own custom cosmetic player providers to use throughout their plugin.

```java
class MyPlugin extends JavaPlugin {
  public void onEnable() {
    HMCCosmeticsAPI.registerCosmeticUserProvider(new MyUserProvider(this));
  }
}

class MyUserProvider implements CosmeticUserProvider {
  private final Plugin plugin;
  
  public MyUserProvider(Plugin plugin) {
    this.plugin = plugin;
  }
  
  @Override
  public CosmeticUser createCosmeticUser(UUID uuid, UserData userData) {
    return new CustomCosmeticUser(uuid, userData);
  }
  
  @Override
  public Plugin getProviderPlugin() {
    return plugin;
  }
}

class CustomCosmeticUser extends CosmeticUser {
  public CustomCosmeticUser(UUID uuid, UserData data) {
    super(uuid, data);
  }
}
```
This allows for easier Cosmetic User lifecycle management.
```java
class Listeners implements Listener {
  @EventHandler
  public void onEvent(PlayerLoadEvent event) {
    if(!(event.getUser() instanceof CustomCosmeticUser user)) {
      return;
    }
    
    user./*custom methods.*/();
  }
}
```

#### Check that:
- [X] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [X] Syntax and style are consistent with existing code
- [X] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
