### PR TITLE
Removal of `@Getter` and `@Setter`

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/api/events/PlayerCosmeticEvent.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/api/events/PlayerCosmeticEvent.java
@@ -1,7 +1,6 @@
 package com.hibiscusmc.hmccosmetics.api.events;
 
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
-import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
 /**


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [x] Minor change
- [x] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [x] Documentation (Changes to README files and/or JavaDocs)
- [x] Style (Changes that don't affect the meaning of the code)
- [x] Performance

#### Please describe the changes this PR makes and why it should be merged:
### Goals
- Removing the usage of Lombok `@Getter` and `@Setter` annotations and replacing them with explicitly defined getter and setter methods. 
- Clean up unused imports 

This PR **does not** alter any underlying logic or functionality. Instead, the goal is to improve code readability, maintainability, and overall performance.

Explicit getter and setter methods provide better visibility into the code and make it easier for developers to understand and debug. 

#### Check that:
- [ ] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [ ] Syntax and style are consistent with existing code
- [ ] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
