### PR TITLE
Force Tick Task to Dispatch On CosmeticUser Create

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerConnectionListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerConnectionListener.java
@@ -55,6 +55,7 @@ public class PlayerConnectionListener implements Listener {
                     CosmeticUser cosmeticUser = CosmeticUsers.getProvider()
                         .createCosmeticUser(uuid)
                         .initialize(userData);
+                    cosmeticUser.startTicking();
 
                     CosmeticUsers.addUser(cosmeticUser);
                     MessagesUtil.sendDebugMessages("Run User Join for " + uuid);

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -163,7 +163,7 @@ public class CosmeticUser {
 
     /**
      * Start ticking against the {@link CosmeticUser}.
-     * @implNote The tick-rate is determined by the {@link Settings#getTickPeriod()}, if it is less-than or equal to 0
+     * @implNote The tick-rate is determined by the tick period specified in the configuration, if it is less-than or equal to 0
      * there will be no {@link BukkitTask} created, and the {@link CosmeticUser#taskId} will be -1
      */
     public final void startTicking() {
@@ -180,7 +180,7 @@ public class CosmeticUser {
     /**
      * Dispatch an operation to happen against this {@link CosmeticUser}
      * at a pre-determined tick-rate.
-     * The tick-rate is determined by the {@link Settings#getTickPeriod()}.
+     * The tick-rate is determined by the tick period specified in the configuration.
      */
     protected void tick() {
         MessagesUtil.sendDebugMessages("Tick[uuid=" + uniqueId + "]", Level.INFO);


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [X] Major breaking change
- [X] Refactoring (Changes that dont't fix or add new features *but do* modify source files)

#### Please describe the changes this PR makes and why it should be merged:
Allow overriding the implementation of the tick cycle of a CosmeticUser while also forcing the `CosmeticUser#startTicking` method to be ran when the CosmeticUser has been initialized so it is no longer dependent on `CosmeticUser#initialize` calling it.

#### Check that:
- [X] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [X] Syntax and style are consistent with existing code
- [X] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
