### PR TITLE
fix PlayerMenuOpenEvent can't cancel

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
@@ -182,18 +182,25 @@ public class Menu {
             if (taskid.get() != -1) Bukkit.getScheduler().cancelTask(taskid.get());
         });
 
+        Runnable openGuiTask = () -> {
+            gui.open(viewer);
+            updateMenu(viewer, cosmeticHolder, gui); // fixes shading? I know I do this twice but it's easier than writing a whole new class to deal with this shit
+        };
+
         // API
         if (cosmeticHolder instanceof CosmeticUser user) {
             PlayerMenuOpenEvent event = new PlayerMenuOpenEvent(user, this);
-            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> Bukkit.getPluginManager().callEvent(event));
-            if (event.isCancelled()) return;
+            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
+                Bukkit.getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
+                    openGuiTask.run();
+                }
+            });
         }
         // Internal
-
-        Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
-            gui.open(viewer);
-            updateMenu(viewer, cosmeticHolder, gui); // fixes shading? I know I do this twice but it's easier than writing a whole new class to deal with this shit
-        });
+        else {
+            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), openGuiTask);
+        }
     }
 
     private void updateMenu(Player viewer, CosmeticHolder cosmeticHolder, Gui gui) {


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [ ] Major breaking change
- [ ] Minor change
- [ ] Feature implementation
- [x] Bug fix
- [ ] Chore (Changes that don't fix or add new features *and don't* modify source files)
- [ ] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [ ] Documentation (Changes to README files and/or JavaDocs)
- [ ] Style (Changes that don't affect the meaning of the code)
- [ ] Performance
- [ ] Other (Please specify below)

#### Please describe the changes this PR makes and why it should be merged:
The cancellation status should not be checked in async threads, as it will always execute before other Listeners, preventing them from properly cancelling the event.


#### Check that:
- [x] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [x] Syntax and style are consistent with existing code
- [x] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
