### PR TITLE
Folia Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,6 +181,7 @@ bukkit {
     load = BukkitPluginDescription.PluginLoadOrder.POSTWORLD
     main = "com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin"
     apiVersion = "1.20"
+    foliaSupported = true
     authors = listOf("LoJoSho")
     depend = listOf("HibiscusCommons")
     softDepend = listOf("Nexo", "BetterHud", "ModelEngine", "Oraxen", "ItemsAdder", "Geary", "HMCColor", "WorldGuard", "MythicMobs", "PlaceholderAPI", "SuperVanish", "PremiumVanish", "LibsDisguises", "Denizen", "MMOItems", "Eco")

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/HMCCosmeticsPlugin.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/HMCCosmeticsPlugin.java
@@ -25,6 +25,7 @@ import com.hibiscusmc.hmccosmetics.listener.ServerListener;
 import com.hibiscusmc.hmccosmetics.packets.CosmeticPacketInterface;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUsers;
+import com.hibiscusmc.hmccosmetics.util.FoliaScheduler;
 import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import com.hibiscusmc.hmccosmetics.util.TranslationUtil;
 import me.lojosho.hibiscuscommons.HibiscusCommonsPlugin;
@@ -51,6 +52,15 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
     private static HMCCosmeticsPlugin instance;
     private static YamlConfigurationLoader configLoader;
 
+    /** Folia-aware scheduler shared across the plugin. */
+    private FoliaScheduler folia;
+
+    /** Instance accessor for the scheduler. Prefer entity/region methods on Folia. */
+    public FoliaScheduler scheduler() { return folia; }
+
+    /** Static convenience accessor. */
+    public static FoliaScheduler schedulerStatic() { return getInstance().scheduler(); }
+
     public HMCCosmeticsPlugin() {
         super(13873, 1879);
         new HookHMCCosmetics();
@@ -59,8 +69,14 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
 
     @Override
     public void onStart() {
-        // Plugin startup logic
         instance = this;
+
+        // Initialize Folia-aware scheduler early.
+        this.folia = new FoliaScheduler(this);
+
+        getLogger().info("[HMCCosmetics] Runtime: " + (isFoliaEnvironment()
+                ? "Folia (region/async schedulers enabled)"
+                : "Paper/Spigot (Bukkit scheduler fallback)"));
 
         // File setup
         saveDefaultConfig();
@@ -87,18 +103,22 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
             e.printStackTrace();
         }
 
-        // Move this over to Hibiscus Commons later
-        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) new HMCPlaceholderExpansion().register();
+        // PAPI
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new HMCPlaceholderExpansion().register();
+        }
 
-        // Setup
+        // Setup domain
         setup();
         setPacketInterface(new CosmeticPacketInterface());
 
         // Commands
-        getServer().getPluginCommand("cosmetic").setExecutor(new CosmeticCommand());
-        getServer().getPluginCommand("cosmetic").setTabCompleter(new CosmeticCommandTabComplete());
+        if (getServer().getPluginCommand("cosmetic") != null) {
+            getServer().getPluginCommand("cosmetic").setExecutor(new CosmeticCommand());
+            getServer().getPluginCommand("cosmetic").setTabCompleter(new CosmeticCommandTabComplete());
+        }
 
-        // Listener
+        // Listeners
         getServer().getPluginManager().registerEvents(new PlayerConnectionListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerGameListener(), this);
         getServer().getPluginManager().registerEvents(new ServerListener(), this);
@@ -106,27 +126,28 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
         if (HibiscusCommonsPlugin.isOnPaper()) {
             getServer().getPluginManager().registerEvents(new PaperPlayerGameListener(), this);
         }
+
         // Database
         new Database();
 
-        // WorldGuard
+        // WorldGuard move check listener
         if (Bukkit.getPluginManager().getPlugin("WorldGuard") != null && Settings.isWorldGuardMoveCheck()) {
             getServer().getPluginManager().registerEvents(new WGListener(), this);
         }
 
-        // HMCColor
+        // Optional HMCColor integration
         if (Hooks.isActiveHook("HMCColor")) {
             try {
                 DyeMenuProvider.setDyeMenuProvider(new HMCColorDyeMenu());
             } catch (IllegalStateException e) {
-                getLogger().warning("Unable to set HMCColor as the dye menu. There is likely another plugin registering another dye menu.");
+                getLogger().warning("Unable to set HMCColor as the dye menu. Another plugin likely registered a dye menu first.");
             }
         }
     }
 
     @Override
     public void onLoad() {
-        // WorldGuard
+        // WorldGuard flags
         if (Bukkit.getPluginManager().getPlugin("WorldGuard") != null) {
             new WGHook();
         }
@@ -154,14 +175,13 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
 
         // Configuration setup
         final File file = Path.of(getInstance().getDataFolder().getPath(), "config.yml").toFile();
-        final YamlConfigurationLoader loader = YamlConfigurationLoader.
-                builder().
-                path(file.toPath()).
-                defaultOptions(opts ->
-                        opts.serializers(build -> {
-                            build.register(Location.class, LocationSerializer.INSTANCE);
-                            build.register(ItemStack.class, ItemSerializer.INSTANCE);
-                        }))
+        final YamlConfigurationLoader loader = YamlConfigurationLoader
+                .builder()
+                .path(file.toPath())
+                .defaultOptions(opts -> opts.serializers(build -> {
+                    build.register(Location.class, LocationSerializer.INSTANCE);
+                    build.register(ItemStack.class, ItemSerializer.INSTANCE);
+                }))
                 .nodeStyle(NodeStyle.BLOCK)
                 .build();
         try {
@@ -175,14 +195,13 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
 
         // Messages setup
         final File messagesFile = Path.of(getInstance().getDataFolder().getPath(), "messages.yml").toFile();
-        final YamlConfigurationLoader messagesLoader = YamlConfigurationLoader.
-                builder().
-                path(messagesFile.toPath()).
-                defaultOptions(opts ->
-                        opts.serializers(build -> {
-                            build.register(Location.class, LocationSerializer.INSTANCE);
-                            build.register(ItemStack.class, ItemSerializer.INSTANCE);
-                        }))
+        final YamlConfigurationLoader messagesLoader = YamlConfigurationLoader
+                .builder()
+                .path(messagesFile.toPath())
+                .defaultOptions(opts -> opts.serializers(build -> {
+                    build.register(Location.class, LocationSerializer.INSTANCE);
+                    build.register(ItemStack.class, ItemSerializer.INSTANCE);
+                }))
                 .nodeStyle(NodeStyle.BLOCK)
                 .build();
         try {
@@ -193,9 +212,9 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
 
         // Translation setup
         final File translationFile = Path.of(getInstance().getDataFolder().getPath(), "translations.yml").toFile();
-        final YamlConfigurationLoader translationLoader = YamlConfigurationLoader.
-                builder().
-                path(translationFile.toPath())
+        final YamlConfigurationLoader translationLoader = YamlConfigurationLoader
+                .builder()
+                .path(translationFile.toPath())
                 .nodeStyle(NodeStyle.BLOCK)
                 .build();
         try {
@@ -204,38 +223,23 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
             throw new RuntimeException(e);
         }
 
-        // Cosmetics setup
+        // Cosmetics & Menus
         Cosmetics.setup();
-
-        // Menus setup
         Menus.setup();
 
-        // For reloads
-        /*
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            CosmeticUser user = CosmeticUsers.getUser(player.getUniqueId());
-            if (user == null) continue;
-            for (Cosmetic cosmetic : user.getCosmetic()) {
-                Color color = user.getCosmeticColor(cosmetic.getSlot());
-                Cosmetic newCosmetic = Cosmetics.getCosmetic(cosmetic.getId());
-                user.removeCosmeticSlot(cosmetic);
-
-                if (newCosmetic == null) continue;
-                user.addPlayerCosmetic(newCosmetic, color);
-            }
-            user.updateCosmetic();
-        }
-         */
+        // Dynamic permissions for cosmetics and menus
         for (Cosmetic cosmetic : Cosmetics.values()) {
             if (cosmetic.getPermission() != null) {
-                if (getInstance().getServer().getPluginManager().getPermission(cosmetic.getPermission()) != null) continue;
-                getInstance().getServer().getPluginManager().addPermission(new Permission(cosmetic.getPermission()));
+                if (getInstance().getServer().getPluginManager().getPermission(cosmetic.getPermission()) == null) {
+                    getInstance().getServer().getPluginManager().addPermission(new Permission(cosmetic.getPermission()));
+                }
             }
         }
         for (Menu menu : Menus.values()) {
             if (menu.getPermissionNode() != null) {
-                if (getInstance().getServer().getPluginManager().getPermission(menu.getPermissionNode()) != null) continue;
-                getInstance().getServer().getPluginManager().addPermission(new Permission(menu.getPermissionNode()));
+                if (getInstance().getServer().getPluginManager().getPermission(menu.getPermissionNode()) == null) {
+                    getInstance().getServer().getPluginManager().addPermission(new Permission(menu.getPermissionNode()));
+                }
             }
         }
 
@@ -246,5 +250,15 @@ public final class HMCCosmeticsPlugin extends HibiscusPlugin {
         getInstance().getLogger().info("Data storage is set to " + DatabaseSettings.getDatabaseType());
 
         Bukkit.getPluginManager().callEvent(new HMCCosmeticSetupEvent());
+    }
+
+    /** Local detection in case callers need it without touching the adapter. */
+    private boolean isFoliaEnvironment() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/database/types/MySQLData.java
@@ -27,6 +27,8 @@ public class MySQLData extends SQLData {
     @Nullable
     private Connection connection;
 
+    private final Object connectionLock = new Object();
+
     @Override
     public void setup() {
         host = DatabaseSettings.getHost();
@@ -39,63 +41,84 @@ public class MySQLData extends SQLData {
         try {
             openConnection();
             if (connection == null) throw new IllegalStateException("Connection is null");
-            try (PreparedStatement preparedStatement =  connection.prepareStatement("CREATE TABLE IF NOT EXISTS `COSMETICDATABASE` " +
-                    "(UUID varchar(36) PRIMARY KEY, " +
-                    "COSMETICS MEDIUMTEXT " +
-                    ");")) {
+            try (PreparedStatement preparedStatement = connection.prepareStatement(
+                    "CREATE TABLE IF NOT EXISTS `COSMETICDATABASE` (" +
+                            "UUID varchar(36) PRIMARY KEY," +
+                            "COSMETICS MEDIUMTEXT" +
+                            ");")) {
                 preparedStatement.execute();
             }
         } catch (SQLException | IllegalStateException e) {
             plugin.getLogger().severe("");
-            plugin.getLogger().severe("");
             plugin.getLogger().severe("MySQL DATABASE CAN NOT BE REACHED.");
             plugin.getLogger().severe("CHECK CONFIG FOR ERRORS");
-            plugin.getLogger().severe("");
             plugin.getLogger().severe("SAFETY SHUTTING DOWN SERVER");
             plugin.getLogger().severe("");
-            plugin.getLogger().severe("");
-            Bukkit.shutdown();
+
+            // Ensure shutdown on the main/global context in Folia
+            plugin.scheduler().runGlobal(() -> {
+                plugin.getLogger().log(Level.SEVERE, "Shutting down due to database initialization failure.", e);
+                Bukkit.shutdown();
+            });
+
             throw new RuntimeException(e);
         }
     }
 
     @Override
     public void clear(UUID uniqueId) {
-        Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
+        HMCCosmeticsPlugin.getInstance().scheduler().runAsync(() -> {
             try (PreparedStatement preparedSt = preparedStatement("DELETE FROM COSMETICDATABASE WHERE UUID=?;")) {
+                if (preparedSt == null) return;
                 preparedSt.setString(1, uniqueId.toString());
                 preparedSt.executeUpdate();
             } catch (SQLException e) {
-                e.printStackTrace();
+                HMCCosmeticsPlugin.getInstance().getLogger().log(Level.SEVERE, "Failed to clear user row: " + uniqueId, e);
             }
         });
     }
 
     private void openConnection() throws SQLException {
-        // Connection isn't null AND Connection isn't closed :: return
-        try {
-            if (isConnectionOpen()) return;
-            if (connection != null) close(); // Close connection if still active
-        } catch (RuntimeException e) {
-            e.printStackTrace(); // If isConnectionOpen() throws error
-        }
+        synchronized (connectionLock) {
+            try {
+                if (isConnectionOpen()) return;
+                if (connection != null) {
+                    try {
+                        connection.close();
+                    } catch (SQLException ignored) {}
+                    connection = null;
+                }
+            } catch (RuntimeException ex) {
+                // ignore state check issues, we will try to open fresh
+            }
 
-        // Connect to database host
-        try {
-            Class.forName("com.mysql.jdbc.Driver");
-            connection = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database, setupProperties());
-        } catch (SQLException | ClassNotFoundException e) {
-            System.out.println(e.getMessage());
+            try {
+                // Modern MySQL driver
+                Class.forName("com.mysql.cj.jdbc.Driver");
+            } catch (ClassNotFoundException e) {
+                HMCCosmeticsPlugin.getInstance().getLogger().log(Level.SEVERE, "MySQL driver not found (com.mysql.cj.jdbc.Driver).", e);
+                throw new SQLException("MySQL driver not found", e);
+            }
+
+            final String url =
+                    "jdbc:mysql://" + host + ":" + port + "/" + database + setupProperties();
+
+            connection = DriverManager.getConnection(url, setupProperties());
         }
     }
 
     public void close() {
-        Bukkit.getScheduler().runTaskAsynchronously(HMCCosmeticsPlugin.getInstance(), () -> {
-            try {
-                if (connection == null) throw new IllegalStateException("Connection is null");
-                connection.close();
-            } catch (SQLException | NullPointerException e) {
-                System.out.println(e.getMessage());
+        HMCCosmeticsPlugin.getInstance().scheduler().runAsync(() -> {
+            synchronized (connectionLock) {
+                if (connection != null) {
+                    try {
+                        connection.close();
+                    } catch (SQLException e) {
+                        HMCCosmeticsPlugin.getInstance().getLogger().log(Level.WARNING, "Error while closing MySQL connection", e);
+                    } finally {
+                        connection = null;
+                    }
+                }
             }
         });
     }
@@ -105,37 +128,49 @@ public class MySQLData extends SQLData {
         Properties props = new Properties();
         props.setProperty("user", user);
         props.setProperty("password", password);
+
+        // Optional pool-friendly hints (no-op for plain DriverManager but harmless)
+        props.setProperty("maxReconnects", "3");
+        props.setProperty("useServerPrepStmts", "true");
+        props.setProperty("cachePrepStmts", "true");
+        props.setProperty("prepStmtCacheSize", "250");
+        props.setProperty("prepStmtCacheSqlLimit", "2048");
         return props;
     }
 
     private boolean isConnectionOpen() {
-        try {
-            return connection != null && !connection.isClosed();
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
+        synchronized (connectionLock) {
+            try {
+                return connection != null && !connection.isClosed();
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
     @Override
     public PreparedStatement preparedStatement(String query) {
-        PreparedStatement ps = null;
-
         if (!isConnectionOpen()) {
-            MessagesUtil.sendDebugMessages("The MySQL database connection is not open (Could the database been idle for to long?). Reconnecting...", Level.WARNING);
+            MessagesUtil.sendDebugMessages(
+                    "The MySQL database connection is not open (idle timeout?). Reconnecting...",
+                    Level.WARNING
+            );
             try {
                 openConnection();
             } catch (SQLException e) {
-                e.printStackTrace();
+                HMCCosmeticsPlugin.getInstance().getLogger().log(Level.SEVERE, "Failed to reopen MySQL connection.", e);
+                return null;
             }
         }
 
-        try {
-            if (connection == null) throw new IllegalStateException("Connection is null");
-            ps = connection.prepareStatement(query);
-        } catch (SQLException | IllegalStateException e) {
-            e.printStackTrace();
+        synchronized (connectionLock) {
+            try {
+                if (connection == null) throw new IllegalStateException("Connection is null");
+                return connection.prepareStatement(query);
+            } catch (SQLException | IllegalStateException e) {
+                HMCCosmeticsPlugin.getInstance().getLogger().log(Level.SEVERE, "Failed to create PreparedStatement.", e);
+                return null;
+            }
         }
-
-        return ps;
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/Menu.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Menu {
 
@@ -151,56 +151,73 @@ public class Menu {
         Gui gui = Gui.gui()
                 .title(component)
                 .type(GuiType.CHEST)
-                .inventory((title, owner, type) -> Bukkit.createInventory(owner, rows * 9, title))
+                .inventory((t, owner, type) -> Bukkit.createInventory(owner, rows * 9, t))
                 .create();
 
         gui.setDefaultClickAction(event -> event.setCancelled(true));
 
-        AtomicInteger taskid = new AtomicInteger(-1);
+        // Folia-safe repeating updater controlled by this flag
+        AtomicBoolean active = new AtomicBoolean(false);
+
         gui.setOpenGuiAction(event -> {
-            Runnable run = () -> {
-                if (gui.getInventory().getViewers().isEmpty() && taskid.get() != -1) {
-                    Bukkit.getScheduler().cancelTask(taskid.get());
-                }
+            active.set(true);
 
+            // First run immediately on the viewer's entity thread
+            HMCCosmeticsPlugin.getInstance().scheduler().runFor(viewer, () -> {
+                if (!active.get()) return;
                 updateMenu(viewer, cosmeticHolder, gui);
-            };
-
-            if (refreshRate != -1) {
-                taskid.set(Bukkit.getScheduler().scheduleSyncRepeatingTask(HMCCosmeticsPlugin.getInstance(), run, 0, refreshRate));
-            } else {
-                run.run();
-            }
+                if (refreshRate != -1) {
+                    scheduleRefreshLoop(viewer, cosmeticHolder, gui, active);
+                }
+            });
         });
 
         gui.setCloseGuiAction(event -> {
+            active.set(false);
+
             if (cosmeticHolder instanceof CosmeticUser user) {
                 PlayerMenuCloseEvent closeEvent = new PlayerMenuCloseEvent(user, this, event.getReason());
-                Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> Bukkit.getPluginManager().callEvent(closeEvent));
+                HMCCosmeticsPlugin.getInstance().scheduler().runFor(viewer, () ->
+                        Bukkit.getPluginManager().callEvent(closeEvent)
+                );
             }
-
-            if (taskid.get() != -1) Bukkit.getScheduler().cancelTask(taskid.get());
         });
 
         Runnable openGuiTask = () -> {
             gui.open(viewer);
-            updateMenu(viewer, cosmeticHolder, gui); // fixes shading? I know I do this twice but it's easier than writing a whole new class to deal with this shit
+            // immediate update after open to ensure shading/title correctness
+            updateMenu(viewer, cosmeticHolder, gui);
         };
 
-        // API
+        // API event before opening
         if (cosmeticHolder instanceof CosmeticUser user) {
             PlayerMenuOpenEvent event = new PlayerMenuOpenEvent(user, this);
-            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
+            HMCCosmeticsPlugin.getInstance().scheduler().runFor(viewer, () -> {
                 Bukkit.getPluginManager().callEvent(event);
                 if (!event.isCancelled()) {
                     openGuiTask.run();
                 }
             });
+        } else {
+            HMCCosmeticsPlugin.getInstance().scheduler().runFor(viewer, openGuiTask);
         }
-        // Internal
-        else {
-            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), openGuiTask);
-        }
+    }
+
+    /**
+     * Self-rescheduling refresh loop bound to the viewer's entity thread (Folia-safe).
+     */
+    private void scheduleRefreshLoop(Player viewer, CosmeticHolder cosmeticHolder, Gui gui, AtomicBoolean active) {
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(viewer, refreshRate, () -> {
+            if (!active.get() || gui.getInventory().getViewers().isEmpty()) {
+                active.set(false);
+                return;
+            }
+            updateMenu(viewer, cosmeticHolder, gui);
+            // Chain again if still active
+            if (active.get()) {
+                scheduleRefreshLoop(viewer, cosmeticHolder, gui, active);
+            }
+        });
     }
 
     private void updateMenu(Player viewer, CosmeticHolder cosmeticHolder, Gui gui) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/special/impl/HMCColorDyeMenu.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/special/impl/HMCColorDyeMenu.java
@@ -11,7 +11,6 @@ import com.hibiscusmc.hmccosmetics.gui.special.DyeMenu;
 import me.lojosho.hibiscuscommons.hooks.Hooks;
 import me.lojosho.hibiscuscommons.nms.NMSHandlers;
 import me.lojosho.hibiscuscommons.util.AdventureUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -29,6 +28,7 @@ public class HMCColorDyeMenu implements DyeMenu {
         Gui gui = HMCColorApi.createColorMenu(viewer);
         gui.updateTitle(AdventureUtils.MINI_MESSAGE.deserialize(Hooks.processPlaceholders(viewer, Settings.getDyeMenuName())));
         gui.setItem(Settings.getDyeMenuInputSlot(), new GuiItem(originalItem));
+
         gui.setDefaultTopClickAction(event -> {
             if (event.getSlot() == Settings.getDyeMenuOutputSlot()) {
                 ItemStack item = event.getInventory().getItem(Settings.getDyeMenuOutputSlot());
@@ -39,7 +39,9 @@ public class HMCColorDyeMenu implements DyeMenu {
 
                 addCosmetic(viewer, cosmeticHolder, cosmetic, color);
                 event.setCancelled(true);
-            } else event.setCancelled(true);
+            } else {
+                event.setCancelled(true);
+            }
         });
 
         gui.setPlayerInventoryAction(event -> event.setCancelled(true));
@@ -50,9 +52,10 @@ public class HMCColorDyeMenu implements DyeMenu {
     private void addCosmetic(@NotNull Player viewer, @NotNull CosmeticHolder cosmeticHolder, @NotNull Cosmetic cosmetic, @Nullable Color color) {
         cosmeticHolder.addCosmetic(cosmetic, color);
         viewer.setItemOnCursor(new ItemStack(Material.AIR));
-        Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
+        // Close + update a couple ticks later on the viewer's entity thread (Folia-safe)
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(viewer, 2L, () -> {
             viewer.closeInventory();
             cosmeticHolder.updateCosmetic(cosmetic.getSlot());
-        }, 2);
+        });
     }
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeCosmetic.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/gui/type/types/TypeCosmetic.java
@@ -7,7 +7,6 @@ import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticHolder;
 import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetics;
 import com.hibiscusmc.hmccosmetics.cosmetic.types.CosmeticArmorType;
 import com.hibiscusmc.hmccosmetics.gui.action.Actions;
-import com.hibiscusmc.hmccosmetics.gui.special.DyeMenu;
 import com.hibiscusmc.hmccosmetics.gui.special.DyeMenuProvider;
 import com.hibiscusmc.hmccosmetics.gui.type.Type;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
@@ -16,7 +15,6 @@ import me.lojosho.hibiscuscommons.config.serializer.ItemSerializer;
 import me.lojosho.hibiscuscommons.hooks.Hooks;
 import me.lojosho.shaded.configurate.ConfigurationNode;
 import me.lojosho.shaded.configurate.serialize.SerializationException;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.EquipmentSlot;
@@ -57,13 +55,12 @@ public class TypeCosmetic extends Type {
             return;
         }
 
-        boolean isUnEquippingCosmetic = false;
-        if (cosmeticHolder.getCosmetic(cosmetic.getSlot()) == cosmetic) isUnEquippingCosmetic = true;
+        boolean isUnEquippingCosmetic = cosmeticHolder.getCosmetic(cosmetic.getSlot()) == cosmetic;
 
         String dyeClick = Settings.getCosmeticDyeClickType();
-        String requiredClick;
-        if (isUnEquippingCosmetic) requiredClick = Settings.getCosmeticUnEquipClickType();
-        else requiredClick = Settings.getCosmeticEquipClickType();
+        String requiredClick = isUnEquippingCosmetic
+                ? Settings.getCosmeticUnEquipClickType()
+                : Settings.getCosmeticEquipClickType();
 
         MessagesUtil.sendDebugMessages("Required click type: " + requiredClick);
         MessagesUtil.sendDebugMessages("Click type: " + clickType.name());
@@ -105,7 +102,8 @@ public class TypeCosmetic extends Type {
                 MessagesUtil.sendDebugMessages("on-equip");
                 MessagesUtil.sendDebugMessages("Preparing for on-equip with the following checks:");
                 MessagesUtil.sendDebugMessages("CosmeticDyeable? " + cosmetic.isDyeable() + " / isDyeClick? " + isDyeClick + " / isHMCColorActive? " + Hooks.isActiveHook("HMCColor"));
-                // TODO: Redo this
+
+                // If dyeable and dye-click, launch the dye menu; otherwise equip on required click.
                 if (cosmetic.isDyeable() && isDyeClick && DyeMenuProvider.hasMenuProvider()) {
                     DyeMenuProvider.openMenu(viewer, cosmeticHolder, cosmetic);
                 } else if (isRequiredClick) {
@@ -118,14 +116,16 @@ public class TypeCosmetic extends Type {
         } catch (SerializationException e) {
             e.printStackTrace();
         }
-        // Fixes issue with offhand cosmetics not appearing. Yes, I know this is dumb
-        Runnable run = () -> cosmeticHolder.updateCosmetic(cosmetic.getSlot());
-        if (cosmetic instanceof CosmeticArmorType) {
-            if (((CosmeticArmorType) cosmetic).getEquipSlot().equals(EquipmentSlot.OFF_HAND)) {
-                Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), run, 1);
-            }
+
+        // Fixes issue with offhand cosmetics not appearing. Yes, I know this is dumb.
+        Runnable update = () -> cosmeticHolder.updateCosmetic(cosmetic.getSlot());
+        if (cosmetic instanceof CosmeticArmorType && ((CosmeticArmorType) cosmetic).getEquipSlot() == EquipmentSlot.OFF_HAND) {
+            // Folia-safe: run later on the viewer's entity thread.
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(viewer, 1L, update);
+        } else {
+            update.run();
         }
-        run.run();
+
         MessagesUtil.sendDebugMessages("Finished Type Click Run");
     }
 
@@ -159,7 +159,7 @@ public class TypeCosmetic extends Type {
             try {
                 if (equippedItem.node("material").virtual()) equippedItem.node("material").set(config.node("item", "material").getString());
             } catch (SerializationException e) {
-                // Nothing >:)
+                // ignore
             }
             try {
                 itemStack = ItemSerializer.INSTANCE.deserialize(ItemStack.class, equippedItem);
@@ -177,7 +177,7 @@ public class TypeCosmetic extends Type {
             try {
                 if (lockedItem.node("material").virtual()) lockedItem.node("material").set(config.node("item", "material").getString());
             } catch (SerializationException e) {
-                // Nothing >:)
+                // ignore
             }
             try {
                 itemStack = ItemSerializer.INSTANCE.deserialize(ItemStack.class, lockedItem);

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/worldguard/WGListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/hooks/worldguard/WGListener.java
@@ -1,5 +1,6 @@
 package com.hibiscusmc.hmccosmetics.hooks.worldguard;
 
+import com.hibiscusmc.hmccosmetics.HMCCosmeticsPlugin;
 import com.hibiscusmc.hmccosmetics.config.Wardrobe;
 import com.hibiscusmc.hmccosmetics.config.WardrobeSettings;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
@@ -27,17 +28,20 @@ import java.util.Set;
  * Contains {@link com.sk89q.worldguard.WorldGuard WorldGuard} related event listeners
  */
 public class WGListener implements Listener {
+
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerMove(@NotNull PlayerMoveEvent event) {
-        Player player = event.getPlayer();
-        Location from = event.getFrom();
-        Location to = event.getTo();
+        final Player player = event.getPlayer();
+        final Location from = event.getFrom();
+        final Location to = event.getTo();
+        if (to == null) return;
         if (from.getBlockX() == to.getBlockX() && from.getBlockY() == to.getBlockY() && from.getBlockZ() == to.getBlockZ()) return;
 
         CosmeticUser user = CosmeticUsers.getUser(player);
         if (user == null) return;
-        Location location = player.getLocation();
-        ApplicableRegionSet set = getRegions(location);
+
+        // This event is already running on the player's region thread on Folia.
+        ApplicableRegionSet set = getRegions(player.getLocation());
         if (user.isHidden() && set.getRegions().isEmpty()) {
             user.showCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
         }
@@ -45,15 +49,17 @@ public class WGListener implements Listener {
         Set<String> wardrobeNames = WardrobeSettings.getWardrobeNames();
         for (ProtectedRegion protectedRegion : set.getRegions()) {
             Map<Flag<?>, Object> flags = protectedRegion.getFlags();
+
             if (flags.containsKey(WGHook.getCosmeticEnableFlag())) {
-                if (flags.get(WGHook.getCosmeticEnableFlag()).toString().equalsIgnoreCase("ALLOW")) {
+                if (String.valueOf(flags.get(WGHook.getCosmeticEnableFlag())).equalsIgnoreCase("ALLOW")) {
                     user.showCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
                 } else {
                     user.hideCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
                 }
             }
+
             if (flags.containsKey(WGHook.getCosmeticWardrobeFlag())) {
-                String wardrobeName = flags.getOrDefault(WGHook.getCosmeticWardrobeFlag(), "").toString();
+                String wardrobeName = String.valueOf(flags.getOrDefault(WGHook.getCosmeticWardrobeFlag(), ""));
                 if (wardrobeName.isEmpty() || !wardrobeNames.contains(wardrobeName)) return;
                 Wardrobe wardrobe = WardrobeSettings.getWardrobe(wardrobeName);
                 if (wardrobe == null) return;
@@ -64,30 +70,43 @@ public class WGListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerTeleport(PlayerTeleportEvent event) {
-        CosmeticUser user = CosmeticUsers.getUser(event.getPlayer());
+        final Player player = event.getPlayer();
+        final CosmeticUser user = CosmeticUsers.getUser(player);
         if (user == null) return;
-        Location location = event.getTo();
-        ApplicableRegionSet set = getRegions(location);
-        if (user.isHidden()) {
-            if (set.getRegions().isEmpty()) {
+
+        final Location to = event.getTo();
+        if (to == null) return;
+
+        // Run shortly after the teleport on the player's entity thread (Folia-safe).
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, 1L, () -> {
+            ApplicableRegionSet set = getRegions(to);
+
+            if (user.isHidden() && set.getRegions().isEmpty()) {
                 user.showCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
             }
-        }
-        for (ProtectedRegion protectedRegion : set.getRegions()) {
-            if (protectedRegion.getFlags().containsKey(WGHook.getCosmeticEnableFlag())) {
-                if (protectedRegion.getFlags().get(WGHook.getCosmeticEnableFlag()).toString().equalsIgnoreCase("ALLOW")) {
-                    user.showCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
+
+            for (ProtectedRegion protectedRegion : set.getRegions()) {
+                Map<Flag<?>, Object> flags = protectedRegion.getFlags();
+
+                if (flags.containsKey(WGHook.getCosmeticEnableFlag())) {
+                    if (String.valueOf(flags.get(WGHook.getCosmeticEnableFlag())).equalsIgnoreCase("ALLOW")) {
+                        user.showCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
+                    } else {
+                        user.hideCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
+                    }
                     return;
                 }
-                user.hideCosmetics(CosmeticUser.HiddenReason.WORLDGUARD);
-                return;
+
+                if (flags.containsKey(WGHook.getCosmeticWardrobeFlag())) {
+                    String wardrobeName = String.valueOf(flags.get(WGHook.getCosmeticWardrobeFlag()));
+                    if (!WardrobeSettings.getWardrobeNames().contains(wardrobeName)) return;
+                    Wardrobe wardrobe = WardrobeSettings.getWardrobe(wardrobeName);
+                    if (wardrobe != null) {
+                        user.enterWardrobe(wardrobe, true);
+                    }
+                }
             }
-            if (protectedRegion.getFlags().containsKey(WGHook.getCosmeticWardrobeFlag())) {
-                if (!WardrobeSettings.getWardrobeNames().contains(protectedRegion.getFlags().get(WGHook.getCosmeticWardrobeFlag()).toString())) return;
-                Wardrobe wardrobe = WardrobeSettings.getWardrobe(protectedRegion.getFlags().get(WGHook.getCosmeticWardrobeFlag()).toString());
-                user.enterWardrobe(wardrobe, true);
-            }
-        }
+        });
     }
 
     private ApplicableRegionSet getRegions(Location location) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerConnectionListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerConnectionListener.java
@@ -23,33 +23,38 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 
 public class PlayerConnectionListener implements Listener {
+
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(@NotNull PlayerJoinEvent event) {
+        final Player player = event.getPlayer();
+
         if (DatabaseSettings.isEnabledDelay()) {
             MessagesUtil.sendDebugMessages("Delay Enabled with " + DatabaseSettings.getDelayLength() + " ticks");
-            Bukkit.getScheduler().runTaskLater(
-                HMCCosmeticsPlugin.getInstance(),
-                () -> this.loadUserData(event.getPlayer()),
-                DatabaseSettings.getDelayLength()
-            );
+            HMCCosmeticsPlugin.getInstance().scheduler()
+                    .runForLater(player, DatabaseSettings.getDelayLength(), () -> this.loadUserData(player));
         } else {
-            this.loadUserData(event.getPlayer());
+            this.loadUserData(player);
         }
     }
 
     private void loadUserData(final Player player) {
-        if(!player.isOnline()) return;
+        if (player == null || !player.isOnline()) return;
         final UUID playerId = player.getUniqueId();
 
         PlayerPreLoadEvent preLoadEvent = new PlayerPreLoadEvent(playerId);
         Bukkit.getPluginManager().callEvent(preLoadEvent);
         if (preLoadEvent.isCancelled()) return;
 
+        // DB.get(...) runs asynchronously; when complete, bounce back to the player's entity region.
         Database.get(playerId).thenAccept(userData -> {
-            Bukkit.getScheduler().runTask(HMCCosmeticsPlugin.getInstance(), () -> {
+            // Player might have disconnected while we were loading:
+            final Player live = Bukkit.getPlayer(playerId);
+            if (live == null || !live.isOnline()) return;
+
+            HMCCosmeticsPlugin.getInstance().scheduler().runFor(live, () -> {
                 CosmeticUser cosmeticUser = CosmeticUsers.getProvider()
-                    .createCosmeticUser(playerId)
-                    .initialize(userData);
+                        .createCosmeticUser(playerId)
+                        .initialize(userData);
                 cosmeticUser.startTicking();
 
                 CosmeticUsers.addUser(cosmeticUser);
@@ -58,11 +63,12 @@ public class PlayerConnectionListener implements Listener {
                 PlayerLoadEvent playerLoadEvent = new PlayerLoadEvent(cosmeticUser);
                 Bukkit.getPluginManager().callEvent(playerLoadEvent);
 
-                // And finally, launch an update for the cosmetics they have.
-                Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
-                    if (cosmeticUser.getPlayer() == null) return;
-                    cosmeticUser.updateCosmetic();
-                }, 4);
+                // Finally, update the cosmetics they have (slight delay).
+                HMCCosmeticsPlugin.getInstance().scheduler()
+                        .runForLater(live, 4L, () -> {
+                            if (cosmeticUser.getPlayer() == null) return;
+                            cosmeticUser.updateCosmetic();
+                        });
             });
         }).exceptionally(ex -> {
             MessagesUtil.sendDebugMessages("Unable to load Cosmetic User " + playerId + ". Exception: " + ex.getMessage());
@@ -73,7 +79,7 @@ public class PlayerConnectionListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerQuit(@NotNull PlayerQuitEvent event) {
         CosmeticUser user = CosmeticUsers.getUser(event.getPlayer());
-        if (user == null) return; // Player never initialized, don't do anything
+        if (user == null) return; // Player never initialized; nothing to do
 
         PlayerPreUnloadEvent preUnloadEvent = new PlayerPreUnloadEvent(user);
         Bukkit.getPluginManager().callEvent(preUnloadEvent);
@@ -86,7 +92,7 @@ public class PlayerConnectionListener implements Listener {
             user.leaveWardrobe(true);
 
             final Player player = user.getPlayer();
-            if(player != null) player.setInvisible(false);
+            if (player != null) player.setInvisible(false);
         }
         Menus.removeCooldown(event.getPlayer().getUniqueId()); // Removes any menu cooldowns a player might have
         Database.save(user);
@@ -99,12 +105,12 @@ public class PlayerConnectionListener implements Listener {
         if (event.getPlayer().isOp() || event.getPlayer().hasPermission("hmccosmetics.notifyupdate")) {
             if (!HMCCosmeticsPlugin.getInstance().getLatestVersion().equalsIgnoreCase(HMCCosmeticsPlugin.getInstance().getDescription().getVersion()) && HMCCosmeticsPlugin.getInstance().getLatestVersion().isEmpty())
                 MessagesUtil.sendMessageNoKey(
-                    event.getPlayer(),
-                    "<br>" +
-                        "<GRAY>There is a new version of <light_purple><Bold>HMCCosmetics<reset><gray> available!<br>" +
-                        "<GRAY>Current version: <red>" + HMCCosmeticsPlugin.getInstance().getDescription().getVersion() + " <GRAY>| Latest version: <light_purple>" + HMCCosmeticsPlugin.getInstance().getLatestVersion() + "<br>" +
-                        "<GRAY>Download it on <gold><click:OPEN_URL:'https://www.spigotmc.org/resources/100107/'>Spigot<reset> <gray>or <gold><click:OPEN_URL:'https://polymart.org/resource/1879'>Polymart<reset><gray>!" +
-                        "<br>"
+                        event.getPlayer(),
+                        "<br>" +
+                                "<GRAY>There is a new version of <light_purple><Bold>HMCCosmetics<reset><gray> available!<br>" +
+                                "<GRAY>Current version: <red>" + HMCCosmeticsPlugin.getInstance().getDescription().getVersion() + " <GRAY>| Latest version: <light_purple>" + HMCCosmeticsPlugin.getInstance().getLatestVersion() + "<br>" +
+                                "<GRAY>Download it on <gold><click:OPEN_URL:'https://www.spigotmc.org/resources/100107/'>Spigot<reset> <gray>or <gold><click:OPEN_URL:'https://polymart.org/resource/1879'>Polymart<reset><gray>!" +
+                                "<br>"
                 );
         }
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PlayerGameListener.java
@@ -15,10 +15,8 @@ import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import com.hibiscusmc.hmccosmetics.util.packets.HMCCPacketManager;
 import me.lojosho.hibiscuscommons.api.events.*;
 import me.lojosho.hibiscuscommons.util.packets.PacketManager;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -62,9 +60,10 @@ public class PlayerGameListener implements Listener {
         CosmeticSlot cosmeticSlot = HMCCInventoryUtils.BukkitCosmeticSlot(slot);
         if (cosmeticSlot == null) return;
         if (!user.hasCosmeticInSlot(cosmeticSlot)) return;
-        Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
-            user.updateCosmetic(cosmeticSlot);
-        }, 1);
+
+        if (event.getWhoClicked() instanceof Player p) {
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(p, 1L, () -> user.updateCosmetic(cosmeticSlot));
+        }
         MessagesUtil.sendDebugMessages("Event fired, updated cosmetic " + cosmeticSlot);
     }
 
@@ -93,7 +92,7 @@ public class PlayerGameListener implements Listener {
             user.leaveWardrobe(false);
         }
 
-        Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(event.getPlayer(), 2L, () -> {
             if (user.getEntity() == null || user.isInWardrobe()) return; // fixes disconnecting when in wardrobe (the entity stuff)
             if (Settings.getDisabledWorlds().contains(user.getEntity().getLocation().getWorld().getName())) {
                 user.hideCosmetics(CosmeticUser.HiddenReason.WORLD);
@@ -107,7 +106,7 @@ public class PlayerGameListener implements Listener {
                 user.respawnBalloon();
             }
             user.updateCosmetic();
-        }, 2);
+        });
 
         if (event.getCause().equals(PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) || event.getCause().equals(PlayerTeleportEvent.TeleportCause.END_PORTAL)) return;
     }
@@ -131,10 +130,10 @@ public class PlayerGameListener implements Listener {
         if (user.hasCosmeticInSlot(CosmeticSlot.BALLOON)) {
             user.despawnBalloon();
 
-            Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(event.getPlayer(), 4L, () -> {
                 user.spawnBalloon((CosmeticBalloonType) user.getCosmetic(CosmeticSlot.BALLOON));
                 user.updateCosmetic();
-            }, 4);
+            });
         }
     }
 
@@ -216,10 +215,10 @@ public class PlayerGameListener implements Listener {
             return;
         }
 
-        Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(event.getPlayer(), 2L, () -> {
             MessagesUtil.sendDebugMessages("PlayerItemDamageEvent UpdateCosmetic " + cosmeticSlot);
             user.updateCosmetic(cosmeticSlot);
-        }, 2);
+        });
     }
 
     @EventHandler(priority = EventPriority.LOW)
@@ -227,14 +226,19 @@ public class PlayerGameListener implements Listener {
         CosmeticUser user = CosmeticUsers.getUser(event.getPlayer().getUniqueId());
         if (user == null) return;
         // Really need to look into optimization of this
-        Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(event.getPlayer(), 2L, () -> {
             if (user.getEntity() == null) return; // Player has likely logged off
             user.updateCosmetic(CosmeticSlot.OFFHAND);
             List<Player> viewers = HMCCPacketManager.getViewers(user.getEntity().getLocation());
             if (viewers.isEmpty()) return;
             viewers.remove(user.getPlayer());
-            PacketManager.equipmentSlotUpdate(user.getEntity().getEntityId(), EquipmentSlot.HAND, event.getPlayer().getInventory().getItemInMainHand(), viewers);
-        }, 2);
+            PacketManager.equipmentSlotUpdate(
+                    user.getEntity().getEntityId(),
+                    EquipmentSlot.HAND,
+                    event.getPlayer().getInventory().getItemInMainHand(),
+                    viewers
+            );
+        });
     }
 
     @EventHandler(priority = EventPriority.NORMAL)
@@ -269,9 +273,9 @@ public class PlayerGameListener implements Listener {
 
         //NMSHandlers.getHandler().slotUpdate(event.getPlayer(), event.getPreviousSlot());
         if (user.hasCosmeticInSlot(CosmeticSlot.MAINHAND)) {
-            Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(event.getPlayer(), 2L, () -> {
                 user.updateCosmetic(CosmeticSlot.MAINHAND);
-            }, 2);
+            });
         }
 
         // #84, Riptides mess with backpacks
@@ -338,24 +342,24 @@ public class PlayerGameListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void onPlayerMounted(EntityMountEvent event) {
-		if (event.getEntity() instanceof Player player) {
+    public void onPlayerMounted(EntityMountEvent event) {
+        if (event.getEntity() instanceof Player player) {
             CosmeticUser user = CosmeticUsers.getUser(player);
             if (user == null) return;
 
-            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(HMCCosmeticsPlugin.getInstance(), user::respawnBackpack, 1);
-		}
-	}
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, 1L, user::respawnBackpack);
+        }
+    }
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void onPlayerDismounted(EntityDismountEvent event) {
-		if (event.getDismounted() instanceof Player player) {
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerDismounted(EntityDismountEvent event) {
+        if (event.getDismounted() instanceof Player player) {
             CosmeticUser user = CosmeticUsers.getUser(player);
             if (user == null) return;
 
-            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(HMCCosmeticsPlugin.getInstance(), user::respawnBackpack, 1);
-		}
-	}
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, 1L, user::respawnBackpack);
+        }
+    }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEntityEvent event) {

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/packets/CosmeticPacketInterface.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/packets/CosmeticPacketInterface.java
@@ -155,9 +155,9 @@ public class CosmeticPacketInterface implements PacketInterface {
     public PacketAction readPlayerScale(@NotNull Player player, @NotNull PlayerScaleWrapper wrapper) {
         int entityId = wrapper.getEntityId();
         Player changedPlayer = Bukkit.getOnlinePlayers().stream()
-            .filter(onlinePlayer -> onlinePlayer.getEntityId() == entityId)
-            .findFirst()
-            .orElse(null);
+                .filter(onlinePlayer -> onlinePlayer.getEntityId() == entityId)
+                .findFirst()
+                .orElse(null);
         if (changedPlayer == null) return PacketAction.NOTHING;
 
         CosmeticUser cosmeticUser = CosmeticUsers.getUser(changedPlayer.getUniqueId());
@@ -184,7 +184,8 @@ public class CosmeticPacketInterface implements PacketInterface {
         CosmeticSlot cosmeticSlot = HMCCInventoryUtils.NMSCosmeticSlot(slotNumber);
         if (cosmeticSlot == null || !user.hasCosmeticInSlot(cosmeticSlot)) return PacketAction.NOTHING;
 
-        Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> user.updateCosmetic(cosmeticSlot), 1);
+        // Folia-safe: perform the update one tick later on the player's entity thread
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, 1L, () -> user.updateCosmetic(cosmeticSlot));
         MessagesUtil.sendDebugMessages("Packet fired, updated cosmetic " + cosmeticSlot);
         return PacketAction.NOTHING;
     }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/CosmeticUser.java
@@ -34,20 +34,25 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.*;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 public class CosmeticUser implements CosmeticHolder {
     @Getter
     private final UUID uniqueId;
-    private int taskId = -1;
+
+    // Folia ticking control
+    private final AtomicBoolean ticking = new AtomicBoolean(false);
+    private int tickPeriod = -1;
+
     private final HashMap<CosmeticSlot, Cosmetic> playerCosmetics = new HashMap<>();
     private UserWardrobeManager userWardrobeManager;
     private UserBalloonManager userBalloonManager;
@@ -165,18 +170,35 @@ public class CosmeticUser implements CosmeticHolder {
 
     /**
      * Start ticking against the {@link CosmeticUser}.
-     * @implNote The tick-rate is determined by the tick period specified in the configuration, if it is less-than or equal to 0
-     * there will be no {@link BukkitTask} created, and the {@link CosmeticUser#taskId} will be -1
+     * The tick-rate is determined by the tick period specified in the configuration.
      */
     public final void startTicking() {
-        int tickPeriod = Settings.getTickPeriod();
-        if(tickPeriod <= 0) {
+        int configured = Settings.getTickPeriod();
+        if (configured <= 0) {
             MessagesUtil.sendDebugMessages("CosmeticUser tick is disabled.");
             return;
         }
+        this.tickPeriod = configured;
+        if (ticking.compareAndSet(false, true)) {
+            scheduleTickLoop();
+        }
+    }
 
-        final BukkitTask task = Bukkit.getScheduler().runTaskTimer(HMCCosmeticsPlugin.getInstance(), this::tick, 0, tickPeriod);
-        this.taskId = task.getTaskId();
+    /** Folia-safe self-rescheduling tick loop, bound to the player's entity thread. */
+    private void scheduleTickLoop() {
+        if (!ticking.get()) return;
+        final Player player = getPlayer();
+        if (player == null) {
+            // Player not online; stop ticking for safety.
+            ticking.set(false);
+            return;
+        }
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, tickPeriod, () -> {
+            if (!ticking.get()) return;
+            tick();
+            // Reschedule next tick
+            scheduleTickLoop();
+        });
     }
 
     /**
@@ -201,9 +223,8 @@ public class CosmeticUser implements CosmeticHolder {
     }
 
     public void destroy() {
-        if(this.taskId != -1) { // ensure we're actually ticking this user.
-            Bukkit.getScheduler().cancelTask(taskId);
-        }
+        // Stop Folia tick loop
+        ticking.set(false);
 
         despawnBackpack();
         despawnBalloon();
@@ -364,7 +385,6 @@ public class CosmeticUser implements CosmeticHolder {
     @SuppressWarnings("deprecation")
     public ItemStack getUserCosmeticItem(@NotNull Cosmetic cosmetic, @Nullable ItemStack item) {
         if (item == null) {
-            //MessagesUtil.sendDebugMessages("GetUserCosemticUser Item is null");
             return new ItemStack(Material.AIR);
         }
         if (item.hasItemMeta()) {
@@ -378,7 +398,6 @@ public class CosmeticUser implements CosmeticHolder {
                     owner = Hooks.processPlaceholders(getPlayer(), owner);
 
                     skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(owner));
-                    //skullMeta.getPersistentDataContainer().remove(InventoryUtils.getSkullOwner()); // Don't really need this?
                 }
                 if (skullMeta.getPersistentDataContainer().has(InventoryUtils.getSkullTexture(), PersistentDataType.STRING)) {
                     String texture = skullMeta.getPersistentDataContainer().get(InventoryUtils.getSkullTexture(), PersistentDataType.STRING);
@@ -387,7 +406,6 @@ public class CosmeticUser implements CosmeticHolder {
 
                     Bukkit.getUnsafe().modifyItemStack(item, "{SkullOwner:{Id:[I;0,0,0,0],Properties:{textures:[{Value:\""
                             + texture + "\"}]}}}");
-                    //skullMeta.getPersistentDataContainer().remove(InventoryUtils.getSkullTexture()); // Don't really need this?
                 }
 
                 itemMeta = skullMeta;
@@ -408,7 +426,6 @@ public class CosmeticUser implements CosmeticHolder {
                 }
                 itemMeta.setLore(processedLore);
             }
-
 
             itemMeta.getPersistentDataContainer().set(HMCCInventoryUtils.getCosmeticKey(), PersistentDataType.STRING, cosmetic.getId());
             itemMeta.getPersistentDataContainer().set(InventoryUtils.getOwnerKey(), PersistentDataType.STRING, getEntity().getUniqueId().toString());
@@ -504,13 +521,26 @@ public class CosmeticUser implements CosmeticHolder {
                     WardrobeSettings.getTransitionStay(),
                     WardrobeSettings.getTransitionFadeOut()
             );
-            Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
+            final Player p = getPlayer();
+            if (p != null) {
+                HMCCosmeticsPlugin.getInstance().scheduler().runForLater(p, WardrobeSettings.getTransitionDelay(), () -> {
+                    if (userWardrobeManager != null) {
+                        userWardrobeManager.end();
+                        userWardrobeManager = null;
+                    }
+                });
+            } else {
+                // Fallback: if player vanished mid-transition, just end immediately
+                if (userWardrobeManager != null) {
+                    userWardrobeManager.end();
+                    userWardrobeManager = null;
+                }
+            }
+        } else {
+            if (userWardrobeManager != null) {
                 userWardrobeManager.end();
                 userWardrobeManager = null;
-            }, WardrobeSettings.getTransitionDelay());
-        } else {
-            userWardrobeManager.end();
-            userWardrobeManager = null;
+            }
         }
     }
 
@@ -665,8 +695,6 @@ public class CosmeticUser implements CosmeticHolder {
         if (!hiddenReason.contains(reason)) hiddenReason.add(reason);
         if (hasCosmeticInSlot(CosmeticSlot.BALLOON)) {
             despawnBalloon();
-            //getBalloonManager().removePlayerFromModel(getPlayer());
-            //getBalloonManager().sendRemoveLeashPacket();
         }
         if (hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
             despawnBackpack();
@@ -710,7 +738,6 @@ public class CosmeticUser implements CosmeticHolder {
         updateCosmetic();
         MessagesUtil.sendDebugMessages("ShowCosmetics");
     }
-
 
     /**
      * This method is deprecated and will be removed in the future. Use {@link #isHidden()} instead.

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserWardrobeManager.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/user/manager/UserWardrobeManager.java
@@ -11,8 +11,8 @@ import com.hibiscusmc.hmccosmetics.gui.Menu;
 import com.hibiscusmc.hmccosmetics.gui.Menus;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.util.HMCCInventoryUtils;
-import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import com.hibiscusmc.hmccosmetics.util.HMCCServerUtils;
+import com.hibiscusmc.hmccosmetics.util.MessagesUtil;
 import com.hibiscusmc.hmccosmetics.util.packets.HMCCPacketManager;
 import lombok.Getter;
 import lombok.Setter;
@@ -33,45 +33,31 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class UserWardrobeManager {
 
-    @Getter
-    private final int NPC_ID;
-    @Getter
-    private final int ARMORSTAND_ID;
-    @Getter
-    private final UUID WARDROBE_UUID;
-    @Getter
-    private String npcName;
-    @Getter
-    private GameMode originalGamemode;
-    @Getter
-    private final CosmeticUser user;
-    @Getter
-    private final Wardrobe wardrobe;
-    @Getter
-    private final WardrobeLocation wardrobeLocation;
-    @Getter
-    private final Location viewingLocation;
-    @Getter
-    private final Location npcLocation;
-    @Getter
-    private Location exitLocation;
-    @Getter
-    private BossBar bossBar;
-    @Getter
-    private boolean active;
-    @Setter
-    @Getter
-    private WardrobeStatus wardrobeStatus;
-    @Getter
-    @Setter
-    private Menu lastOpenMenu;
+    @Getter private final int NPC_ID;
+    @Getter private final int ARMORSTAND_ID;
+    @Getter private final UUID WARDROBE_UUID;
+    @Getter private String npcName;
+    @Getter private GameMode originalGamemode;
+    @Getter private final CosmeticUser user;
+    @Getter private final Wardrobe wardrobe;
+    @Getter private final WardrobeLocation wardrobeLocation;
+    @Getter private final Location viewingLocation;
+    @Getter private final Location npcLocation;
+    @Getter private Location exitLocation;
+    @Getter private BossBar bossBar;
+    @Getter private boolean active;
+    @Setter @Getter private WardrobeStatus wardrobeStatus;
+    @Getter @Setter private Menu lastOpenMenu;
+
+    // controls the Folia repeating update loop
+    private final AtomicBoolean updateLoopActive = new AtomicBoolean(false);
 
     public UserWardrobeManager(CosmeticUser user, Wardrobe wardrobe) {
         NPC_ID = me.lojosho.hibiscuscommons.util.ServerUtils.getNextEntityId();
@@ -95,7 +81,8 @@ public class UserWardrobeManager {
 
     public void start() {
         setWardrobeStatus(WardrobeStatus.STARTING);
-        Player player = user.getPlayer();
+        final Player player = user.getPlayer();
+        if (player == null) return;
 
         this.originalGamemode = player.getGameMode();
         if (WardrobeSettings.isReturnLastLocation()) {
@@ -104,13 +91,11 @@ public class UserWardrobeManager {
 
         user.hidePlayer();
         if (!Bukkit.getServer().getAllowFlight()) player.setAllowFlight(true);
-        List<Player> viewer = Collections.singletonList(player);
-        List<Player> outsideViewers = HMCCPacketManager.getViewers(viewingLocation);
-        outsideViewers.remove(player);
+        final List<Player> viewer = Collections.singletonList(player);
 
         MessagesUtil.sendMessage(player, "opened-wardrobe");
 
-        Runnable run = () -> {
+        Runnable startSequence = () -> {
             if (!player.isOnline()) {
                 end();
                 return;
@@ -119,8 +104,9 @@ public class UserWardrobeManager {
             // Armorstand
             HMCCPacketManager.sendEntitySpawnPacket(viewingLocation, ARMORSTAND_ID, EntityType.ARMOR_STAND, UUID.randomUUID(), viewer);
             HMCCPacketManager.sendArmorstandMetadata(ARMORSTAND_ID, viewer);
-            NMSHandlers.getHandler().getPacketHandler().sendTeleportPacket(ARMORSTAND_ID, viewingLocation.getX(), viewingLocation.getY(), viewingLocation.getZ(), viewingLocation.getYaw(), viewingLocation.getPitch(), false, viewer);
-            //NMSHandlers.getHandler().getPacketHandler().sendLookAtPacket(ARMORSTAND_ID, viewingLocation, viewer);
+            NMSHandlers.getHandler().getPacketHandler().sendTeleportPacket(ARMORSTAND_ID,
+                    viewingLocation.getX(), viewingLocation.getY(), viewingLocation.getZ(),
+                    viewingLocation.getYaw(), viewingLocation.getPitch(), false, viewer);
             HMCCPacketManager.sendRotateHeadPacket(ARMORSTAND_ID, viewingLocation, viewer);
 
             // Player
@@ -136,9 +122,9 @@ public class UserWardrobeManager {
             }
             HMCCPacketManager.sendFakePlayerInfoPacket(player, NPC_ID, WARDROBE_UUID, npcName, viewer);
 
-            // NPC 2
-            Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), () -> {
-                if (!user.isInWardrobe()) return; // If a player exits the wardrobe right away, no need to spawn the NPC
+            // Spawn NPC entity a few ticks later (still on player's entity thread)
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, 4L, () -> {
+                if (!user.isInWardrobe()) return; // exited instantly
                 HMCCPacketManager.sendFakePlayerSpawnPacket(npcLocation, WARDROBE_UUID, NPC_ID, viewer);
                 HMCCPacketManager.sendPlayerOverlayPacket(NPC_ID, viewer);
                 MessagesUtil.sendDebugMessages("Spawned Fake Player on " + npcLocation);
@@ -147,30 +133,34 @@ public class UserWardrobeManager {
                 if (scaleAttribute != null) {
                     HMCCPacketManager.sendEntityScalePacket(NPC_ID, scaleAttribute.getValue(), viewer);
                 }
-            }, 4);
+            });
 
-            // Location
+            // Orient NPC
             HMCCPacketManager.sendRotateHeadPacket(NPC_ID, npcLocation, viewer);
             HMCCPacketManager.sendRotationPacket(NPC_ID, npcLocation, true, viewer);
 
-            // Misc
+            // Backpack handling in wardrobe
             if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
-                // Maybe null as backpack maybe despawned before entering
                 if (user.getUserBackpackManager() == null) user.respawnBackpack();
                 if (user.isBackpackSpawned()) {
                     user.getUserBackpackManager().getEntityManager().teleport(npcLocation.clone().add(0, 2, 0));
-                    PacketManager.equipmentSlotUpdate(user.getUserBackpackManager().getFirstArmorStandId(), EquipmentSlot.HEAD, user.getUserCosmeticItem(user.getCosmetic(CosmeticSlot.BACKPACK)), viewer);
+                    PacketManager.equipmentSlotUpdate(
+                            user.getUserBackpackManager().getFirstArmorStandId(),
+                            EquipmentSlot.HEAD,
+                            user.getUserCosmeticItem(user.getCosmetic(CosmeticSlot.BACKPACK)),
+                            viewer
+                    );
                     HMCCPacketManager.ridingMountPacket(NPC_ID, user.getUserBackpackManager().getFirstArmorStandId(), viewer);
                 }
             }
 
+            // Balloon handling in wardrobe
             if (user.hasCosmeticInSlot(CosmeticSlot.BALLOON)) {
                 if (user.getBalloonManager() == null) user.respawnBalloon();
                 if (user.isBalloonSpawned()) {
                     CosmeticBalloonType cosmetic = (CosmeticBalloonType) user.getCosmetic(CosmeticSlot.BALLOON);
                     user.getBalloonManager().sendRemoveLeashPacket(viewer);
                     user.getBalloonManager().sendLeashPacket(NPC_ID);
-                    //PacketManager.sendLeashPacket(VIEWER.getBalloonEntity().getModelId(), NPC_ID, viewer);
 
                     Location balloonLocation = npcLocation.clone().add(cosmetic.getBalloonOffset());
                     HMCCPacketManager.sendTeleportPacket(user.getBalloonManager().getPufferfishBalloonId(), balloonLocation, false, viewer);
@@ -179,26 +169,27 @@ public class UserWardrobeManager {
                 }
             }
 
+            // Bossbar
             if (WardrobeSettings.isEnabledBossbar()) {
                 float progress = WardrobeSettings.getBossbarProgress();
                 Component message = MessagesUtil.processStringNoKey(player, WardrobeSettings.getBossbarMessage());
 
                 bossBar = BossBar.bossBar(message, progress, WardrobeSettings.getBossbarColor(), WardrobeSettings.getBossbarOverlay());
                 Audience target = BukkitAudiences.create(HMCCosmeticsPlugin.getInstance()).player(player);
-
                 target.showBossBar(bossBar);
             }
 
+            // Open default menu on enter
             if (WardrobeSettings.isEnterOpenMenu()) {
                 Menu menu = Menus.getDefaultMenu();
                 if (menu != null) menu.openMenu(user);
             }
 
             this.active = true;
-            update();
+            updateLoopActive.set(true);
+            scheduleUpdateLoop();
             setWardrobeStatus(WardrobeStatus.RUNNING);
         };
-
 
         if (WardrobeSettings.isEnabledTransition()) {
             MessagesUtil.sendTitle(
@@ -208,27 +199,25 @@ public class UserWardrobeManager {
                     WardrobeSettings.getTransitionStay(),
                     WardrobeSettings.getTransitionFadeOut()
             );
-            Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), run, WardrobeSettings.getTransitionDelay());
+            HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, WardrobeSettings.getTransitionDelay(), startSequence);
         } else {
-            run.run();
+            HMCCosmeticsPlugin.getInstance().scheduler().runFor(player, startSequence);
         }
-
     }
 
     public void end() {
         setWardrobeStatus(WardrobeStatus.STOPPING);
-        Player player = user.getPlayer();
-
-        List<Player> viewer = Collections.singletonList(player);
-        List<Player> outsideViewers = HMCCPacketManager.getViewers(viewingLocation);
-        outsideViewers.remove(player);
-
+        final Player player = user.getPlayer();
         if (player == null) return;
-        if (!Bukkit.getServer().getAllowFlight()) player.setAllowFlight(false);
-        MessagesUtil.sendMessage(player, "closed-wardrobe");
 
-        Runnable run = () -> {
+        final List<Player> viewer = Collections.singletonList(player);
+
+        HMCCosmeticsPlugin.getInstance().scheduler().runFor(player, () -> {
             this.active = false;
+            updateLoopActive.set(false);
+
+            if (!Bukkit.getServer().getAllowFlight()) player.setAllowFlight(false);
+            MessagesUtil.sendMessage(player, "closed-wardrobe");
 
             // For Wardrobe Temp Cosmetics
             for (Cosmetic cosmetic : user.getCosmetics()) {
@@ -239,128 +228,128 @@ public class UserWardrobeManager {
                 }
             }
 
-            // NPC
+            // NPC cleanup
             if (user.isBalloonSpawned()) user.getBalloonManager().sendRemoveLeashPacket();
-            HMCCPacketManager.sendEntityDestroyPacket(NPC_ID, viewer); // Success
-            HMCCPacketManager.sendRemovePlayerPacket(player, WARDROBE_UUID, viewer); // Success
+            HMCCPacketManager.sendEntityDestroyPacket(NPC_ID, viewer);
+            HMCCPacketManager.sendRemovePlayerPacket(player, WARDROBE_UUID, viewer);
 
-            // Player
+            // Return camera and visibility
             HMCCPacketManager.sendCameraPacket(player.getEntityId(), viewer);
             user.getPlayer().setInvisible(false);
 
-            // Armorstand
-            HMCCPacketManager.sendEntityDestroyPacket(ARMORSTAND_ID, viewer); // Sucess
+            // Armorstand cleanup
+            HMCCPacketManager.sendEntityDestroyPacket(ARMORSTAND_ID, viewer);
 
-            //PacketManager.sendEntityDestroyPacket(player.getEntityId(), viewer); // Success
+            // Gamemode restoration
             if (WardrobeSettings.isForceExitGamemode()) {
                 MessagesUtil.sendDebugMessages("Force Exit Gamemode " + WardrobeSettings.getExitGamemode());
                 player.setGameMode(WardrobeSettings.getExitGamemode());
-                HMCCPacketManager.gamemodeChangePacket(player, WardrobeSettings.getExitGamemode()); // Success
+                HMCCPacketManager.gamemodeChangePacket(player, WardrobeSettings.getExitGamemode());
             } else {
                 MessagesUtil.sendDebugMessages("Original Gamemode " + this.originalGamemode);
                 player.setGameMode(this.originalGamemode);
-                HMCCPacketManager.gamemodeChangePacket(player, this.originalGamemode); // Success
+                HMCCPacketManager.gamemodeChangePacket(player, this.originalGamemode);
             }
+
             user.showPlayer();
 
             if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK)) {
                 user.respawnBackpack();
-                //PacketManager.ridingMountPacket(player.getEntityId(), VIEWER.getBackpackEntity().getEntityId(), viewer);
             }
 
-            if (user.hasCosmeticInSlot(CosmeticSlot.BALLOON)) {
-                //user.respawnBalloon();
-                //PacketManager.sendLeashPacket(VIEWER.getBalloonEntity().getPufferfishBalloonId(), player.getEntityId(), viewer);
-            }
-
+            // Teleport out
             player.teleport(Objects.requireNonNullElseGet(exitLocation, () -> player.getWorld().getSpawnLocation()), PlayerTeleportEvent.TeleportCause.PLUGIN);
 
+            // Restore equipment visuals
             HashMap<EquipmentSlot, ItemStack> items = new HashMap<>();
             for (EquipmentSlot slot : HMCCInventoryUtils.getPlayerArmorSlots()) {
                 ItemStack item = player.getInventory().getItem(slot);
                 items.put(slot, item);
             }
-            /*
-            if (WardrobeSettings.isEquipPumpkin()) {
-                items.put(EquipmentSlot.HEAD, player.getInventory().getHelmet());
-            }
-             */
             HMCCPacketManager.equipmentSlotUpdate(player.getEntityId(), items, viewer);
 
+            // Clear bossbar
             if (WardrobeSettings.isEnabledBossbar()) {
                 Audience target = BukkitAudiences.create(HMCCosmeticsPlugin.getInstance()).player(player);
-
                 target.hideBossBar(bossBar);
             }
 
             user.updateCosmetic();
-        };
-        run.run();
+        });
     }
 
-    private void update() {
-        final AtomicInteger data = new AtomicInteger();
+    /**
+     * Folia-safe, self-rescheduling update loop bound to the player's entity thread.
+     * Replaces the old BukkitRunnable timer (period: 2 ticks).
+     */
+    private void scheduleUpdateLoop() {
+        final Player player = user.getPlayer();
+        if (player == null) return;
 
-        BukkitRunnable runnable = new BukkitRunnable() {
-            @Override
-            public void run() {
-                Player player = user.getPlayer();
-                if (!active || player == null) {
-                    MessagesUtil.sendDebugMessages("WardrobeEnd[user=" + user.getUniqueId() + ",reason=Active is false]");
-                    this.cancel();
-                    return;
-                }
-                MessagesUtil.sendDebugMessages("WardrobeUpdate[user=" + user.getUniqueId() + ",status=" + getWardrobeStatus() + "]");
-                List<Player> viewer = Collections.singletonList(player);
-                List<Player> outsideViewers = HMCCPacketManager.getViewers(viewingLocation);
-                outsideViewers.remove(player);
+        HMCCosmeticsPlugin.getInstance().scheduler().runForLater(player, 2L, () -> {
+            if (!updateLoopActive.get()) return;
 
-                Location location = npcLocation;
-                int yaw = data.get();
-                location.setYaw(yaw);
-
-                HMCCPacketManager.sendRotateHeadPacket(NPC_ID, location, viewer);
-                user.hidePlayer();
-                int rotationSpeed = WardrobeSettings.getRotationSpeed();
-                int newYaw = HMCCServerUtils.getNextYaw(yaw - 30, rotationSpeed);
-                location.setYaw(newYaw);
-                NMSHandlers.getHandler().getPacketHandler().sendRotationPacket(NPC_ID, newYaw, 0, false, viewer);
-                HMCCPacketManager.sendRotationPacket(NPC_ID, newYaw, true, viewer);
-                int nextyaw = HMCCServerUtils.getNextYaw(yaw, rotationSpeed);
-                data.set(nextyaw);
-
-                for (CosmeticSlot slot : CosmeticSlot.values().values()) {
-                    HMCCPacketManager.equipmentSlotUpdate(NPC_ID, user, slot, viewer);
-                }
-
-                if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK) && user.getUserBackpackManager() != null) {
-                    HMCCPacketManager.sendTeleportPacket(user.getUserBackpackManager().getFirstArmorStandId(), location, false, viewer);
-                    HMCCPacketManager.ridingMountPacket(NPC_ID, user.getUserBackpackManager().getFirstArmorStandId(), viewer);
-                    user.getUserBackpackManager().getEntityManager().setRotation(nextyaw);
-                    HMCCPacketManager.sendEntityDestroyPacket(user.getUserBackpackManager().getFirstArmorStandId(), outsideViewers);
-                }
-
-                if (user.hasCosmeticInSlot(CosmeticSlot.BALLOON) && user.isBalloonSpawned()) {
-                    // The two lines below broke, solved by listening to PlayerCosmeticPostEquipEvent
-                    //PacketManager.sendTeleportPacket(user.getBalloonManager().getPufferfishBalloonId(), npcLocation.add(Settings.getBalloonOffset()), false, viewer);
-                    //user.getBalloonManager().getModelEntity().teleport(npcLocation.add(Settings.getBalloonOffset()));
-                    user.getBalloonManager().sendRemoveLeashPacket(outsideViewers);
-                    if (user.getBalloonManager().getBalloonType() != UserBalloonManager.BalloonType.MODELENGINE) {
-                        HMCCPacketManager.sendEntityDestroyPacket(user.getBalloonManager().getModelId(), outsideViewers);
-                    }
-                    user.getBalloonManager().sendLeashPacket(NPC_ID);
-                }
-
-                if (WardrobeSettings.isEquipPumpkin()) {
-                    PacketManager.equipmentSlotUpdate(user.getPlayer().getEntityId(), EquipmentSlot.HEAD, new ItemStack(Material.CARVED_PUMPKIN), viewer);
-                } else {
-                    HMCCPacketManager.equipmentSlotUpdate(user.getPlayer(), true, viewer); // Optifine dumbassery
-                }
+            if (!active || player == null) {
+                MessagesUtil.sendDebugMessages("WardrobeEnd[user=" + user.getUniqueId() + ",reason=Active is false]");
+                updateLoopActive.set(false);
+                return;
             }
-        };
 
-        runnable.runTaskTimer(HMCCosmeticsPlugin.getInstance(), 0, 2);
+            MessagesUtil.sendDebugMessages("WardrobeUpdate[user=" + user.getUniqueId() + ",status=" + getWardrobeStatus() + "]");
+            List<Player> viewer = Collections.singletonList(player);
+            List<Player> outsideViewers = HMCCPacketManager.getViewers(viewingLocation);
+            outsideViewers.remove(player);
+
+            // We mutate a local copy for yaw to avoid racing across ticks
+            Location location = npcLocation.clone();
+
+            // Maintain per-loop yaw state using PDC-like counter kept here
+            int yaw = loopYaw.get();
+            location.setYaw(yaw);
+
+            HMCCPacketManager.sendRotateHeadPacket(NPC_ID, location, viewer);
+            user.hidePlayer();
+
+            int rotationSpeed = WardrobeSettings.getRotationSpeed();
+            int newYaw = HMCCServerUtils.getNextYaw(yaw - 30, rotationSpeed);
+            location.setYaw(newYaw);
+            NMSHandlers.getHandler().getPacketHandler().sendRotationPacket(NPC_ID, newYaw, 0, false, viewer);
+            HMCCPacketManager.sendRotationPacket(NPC_ID, newYaw, true, viewer);
+            int nextYaw = HMCCServerUtils.getNextYaw(yaw, rotationSpeed);
+            loopYaw.set(nextYaw);
+
+            for (CosmeticSlot slot : CosmeticSlot.values().values()) {
+                HMCCPacketManager.equipmentSlotUpdate(NPC_ID, user, slot, viewer);
+            }
+
+            if (user.hasCosmeticInSlot(CosmeticSlot.BACKPACK) && user.getUserBackpackManager() != null) {
+                HMCCPacketManager.sendTeleportPacket(user.getUserBackpackManager().getFirstArmorStandId(), location, false, viewer);
+                HMCCPacketManager.ridingMountPacket(NPC_ID, user.getUserBackpackManager().getFirstArmorStandId(), viewer);
+                user.getUserBackpackManager().getEntityManager().setRotation(nextYaw);
+                HMCCPacketManager.sendEntityDestroyPacket(user.getUserBackpackManager().getFirstArmorStandId(), outsideViewers);
+            }
+
+            if (user.hasCosmeticInSlot(CosmeticSlot.BALLOON) && user.isBalloonSpawned()) {
+                user.getBalloonManager().sendRemoveLeashPacket(outsideViewers);
+                if (user.getBalloonManager().getBalloonType() != UserBalloonManager.BalloonType.MODELENGINE) {
+                    HMCCPacketManager.sendEntityDestroyPacket(user.getBalloonManager().getModelId(), outsideViewers);
+                }
+                user.getBalloonManager().sendLeashPacket(NPC_ID);
+            }
+
+            if (WardrobeSettings.isEquipPumpkin()) {
+                PacketManager.equipmentSlotUpdate(user.getPlayer().getEntityId(), EquipmentSlot.HEAD, new ItemStack(Material.CARVED_PUMPKIN), viewer);
+            } else {
+                HMCCPacketManager.equipmentSlotUpdate(user.getPlayer(), true, viewer); // Optifine compatibility
+            }
+
+            // re-schedule next tick slice
+            scheduleUpdateLoop();
+        });
     }
+
+    // yaw storage for the update loop (replaces local int in the old BukkitRunnable)
+    private final AtomicInteger loopYaw = new AtomicInteger(0);
 
     public enum WardrobeStatus {
         SETUP,
@@ -368,5 +357,4 @@ public class UserWardrobeManager {
         RUNNING,
         STOPPING,
     }
-
 }

--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/util/FoliaScheduler.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/util/FoliaScheduler.java
@@ -1,0 +1,186 @@
+package com.hibiscusmc.hmccosmetics.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Minimal Folia-aware scheduler for Java.
+ * - On Folia: uses Global/Region/Entity/Async schedulers via reflection.
+ * - Else: falls back to BukkitScheduler (sync/async).
+ *
+ * No compile-time dependency on Folia API required.
+ */
+public final class FoliaScheduler {
+    private final Plugin plugin;
+    private final boolean isFolia;
+
+    public FoliaScheduler(Plugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.isFolia = detectFolia();
+    }
+
+    /* ------------------------ Public API ------------------------ */
+
+    /** Run on global region (sync). */
+    public void runGlobal(Runnable task) {
+        if (isFolia) foliaGlobalRun(task);
+        else Bukkit.getScheduler().runTask(plugin, task);
+    }
+
+    /** Run on global region after delay (ticks). */
+    public void runGlobalLater(long delayTicks, Runnable task) {
+        if (isFolia) foliaGlobalRunDelayed(delayTicks, task);
+        else Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks);
+    }
+
+    /** Run on global region at fixed rate (ticks). */
+    public void runGlobalTimer(long delayTicks, long periodTicks, Runnable task) {
+        if (isFolia) foliaGlobalRunAtFixedRate(delayTicks, periodTicks, task);
+        else Bukkit.getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks);
+    }
+
+    /** Run in the region at a specific location. */
+    public void runAt(Location location, Runnable task) {
+        if (!isFolia || location == null) {
+            Bukkit.getScheduler().runTask(plugin, task);
+            return;
+        }
+        foliaRegionRun(location, task);
+    }
+
+    /** Run in the region of a specific entity (entity-locked). */
+    public void runFor(Entity entity, Runnable task) {
+        if (isFolia && entity != null) foliaEntityRun(entity, task);
+        else Bukkit.getScheduler().runTask(plugin, task);
+    }
+
+    /** Run in the region of a specific entity later (ticks). */
+    public void runForLater(Entity entity, long delayTicks, Runnable task) {
+        if (isFolia && entity != null) foliaEntityRunDelayed(entity, delayTicks, task);
+        else Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks);
+    }
+
+    /** Run async. */
+    public void runAsync(Runnable task) {
+        if (isFolia) foliaAsyncRunNow(task);
+        else Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+    }
+
+    /** Run async after a delay in time units. */
+    public void runAsyncLater(long delay, TimeUnit unit, Runnable task) {
+        if (isFolia) {
+            foliaAsyncRunDelayed(delay, unit, task);
+        } else {
+            long ticks = Math.max(1L, millis(unit.toMillis(delay)) / 50L);
+            Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, task, ticks);
+        }
+    }
+
+    /* ------------------------ Detection ------------------------ */
+
+    private static boolean detectFolia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    /* ------------------------ Folia via reflection ------------------------ */
+
+    private void foliaGlobalRun(Runnable task) {
+        try {
+            Object global = Bukkit.class.getMethod("getGlobalRegionScheduler").invoke(null);
+            Method run = global.getClass().getMethod("run", Plugin.class, Consumer.class);
+            run.invoke(global, plugin, (Consumer<Object>) ignored -> task.run());
+        } catch (Throwable t) {
+            // Fallback just in case
+            Bukkit.getScheduler().runTask(plugin, task);
+        }
+    }
+
+    private void foliaGlobalRunDelayed(long delayTicks, Runnable task) {
+        try {
+            Object global = Bukkit.class.getMethod("getGlobalRegionScheduler").invoke(null);
+            Method run = global.getClass().getMethod("runDelayed", Plugin.class, Consumer.class, long.class);
+            run.invoke(global, plugin, (Consumer<Object>) ignored -> task.run(), delayTicks);
+        } catch (Throwable t) {
+            Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks);
+        }
+    }
+
+    private void foliaGlobalRunAtFixedRate(long delayTicks, long periodTicks, Runnable task) {
+        try {
+            Object global = Bukkit.class.getMethod("getGlobalRegionScheduler").invoke(null);
+            Method run = global.getClass().getMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class);
+            run.invoke(global, plugin, (Consumer<Object>) ignored -> task.run(), delayTicks, periodTicks);
+        } catch (Throwable t) {
+            Bukkit.getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks);
+        }
+    }
+
+    private void foliaRegionRun(Location loc, Runnable task) {
+        try {
+            Object region = Bukkit.class.getMethod("getRegionScheduler").invoke(null);
+            World world = loc.getWorld();
+            Method run = region.getClass().getMethod("run", Plugin.class, World.class, Location.class, Consumer.class);
+            run.invoke(region, plugin, world, loc, (Consumer<Object>) ignored -> task.run());
+        } catch (Throwable t) {
+            Bukkit.getScheduler().runTask(plugin, task);
+        }
+    }
+
+    private void foliaEntityRun(Entity entity, Runnable task) {
+        try {
+            Method getScheduler = entity.getClass().getMethod("getScheduler");
+            Object entityScheduler = getScheduler.invoke(entity);
+            Method run = entityScheduler.getClass().getMethod("run", Plugin.class, Runnable.class, Object.class);
+            run.invoke(entityScheduler, plugin, (Runnable) task, null);
+        } catch (Throwable t) {
+            Bukkit.getScheduler().runTask(plugin, task);
+        }
+    }
+
+    private void foliaEntityRunDelayed(Entity entity, long delayTicks, Runnable task) {
+        try {
+            Method getScheduler = entity.getClass().getMethod("getScheduler");
+            Object entityScheduler = getScheduler.invoke(entity);
+            Method runDelayed = entityScheduler.getClass().getMethod("runDelayed", Plugin.class, Runnable.class, Object.class, long.class);
+            runDelayed.invoke(entityScheduler, plugin, (Runnable) task, null, delayTicks);
+        } catch (Throwable t) {
+            Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks);
+        }
+    }
+
+    private void foliaAsyncRunNow(Runnable task) {
+        try {
+            Object async = Bukkit.class.getMethod("getAsyncScheduler").invoke(null);
+            Method runNow = async.getClass().getMethod("runNow", Plugin.class, Consumer.class);
+            runNow.invoke(async, plugin, (Consumer<Object>) ignored -> task.run());
+        } catch (Throwable t) {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+        }
+    }
+
+    private void foliaAsyncRunDelayed(long delay, TimeUnit unit, Runnable task) {
+        try {
+            Object async = Bukkit.class.getMethod("getAsyncScheduler").invoke(null);
+            Method runDelayed = async.getClass().getMethod("runDelayed", Plugin.class, Consumer.class, long.class, TimeUnit.class);
+            runDelayed.invoke(async, plugin, (Consumer<Object>) ignored -> task.run(), delay, unit);
+        } catch (Throwable t) {
+            long ticks = Math.max(1L, millis(unit.toMillis(delay)) / 50L);
+            Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, task, ticks);
+        }
+    }
+
+    private static long millis(long ms) { return ms; }
+}


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [ ] Major breaking change
- [ ] Minor change
- [x] Feature implementation
- [x] Bug fix
- [ ] Chore (Changes that don't fix or add new features *and don't* modify source files)
- [ ] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [ ] Documentation (Changes to README files and/or JavaDocs)
- [ ] Style (Changes that don't affect the meaning of the code)
- [ ] Performance
- [ ] Other (Please specify below)

#### Please describe the changes this PR makes and why it should be merged:
This is a PR for adding Folia Support with a Global Folia Shim. All methods using `Bukkit.getScheduler()` have been replaced with `HMCCosmeticsPlugin.getInstance().scheduler().<hybrid method from the shim>`

#### Check that:
- [x] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [x] Syntax and style are consistent with existing code
- [x] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** In the case where the new method has the exact same signature as the method it's replacing, mention above that the old method *was* deleted.
