### PR TITLE
fix: avoid inventory resyncs on hotbar changes

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PaperPlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PaperPlayerGameListener.java
@@ -21,8 +21,18 @@ public class PaperPlayerGameListener implements Listener {
         CosmeticUser user = CosmeticUsers.getUser(player);
         if (user == null || user.isInWardrobe()) return;
 
-        for (EquipmentSlot slot : event.getEquipmentChanges().keySet())
-            user.updateCosmetic(equipmentSlotToCosmeticType(slot));
+        boolean armorChanged = false;
+        for (EquipmentSlot slot : event.getEquipmentChanges().keySet()) {
+            CosmeticSlot cosmeticSlot = equipmentSlotToCosmeticType(slot);
+            if (cosmeticSlot == null) continue;
+
+            armorChanged = true;
+            user.updateCosmetic(cosmeticSlot);
+        }
+
+        // Selecting another hotbar slot also fires this event for the main hand. Resyncing the
+        // entire inventory in that case can overwrite client-side creative inventory changes.
+        if (!armorChanged) return;
 
         Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), player::updateInventory, 2);
     }


### PR DESCRIPTION
## Summary
- ignore non-armor entries from `EntityEquipmentChangedEvent`
- only schedule `Player#updateInventory()` when an armor slot changed
- prevent hotbar selection changes from forcing a full inventory resync in creative mode

`EntityEquipmentChangedEvent` also fires for `EquipmentSlot.HAND` when a player changes the selected hotbar slot. The previous unconditional inventory update could overwrite client-side creative inventory changes and make hotbar items disappear.

## Testing
- Gradle 8.14.2 clean build (offline)
- 14 actionable tasks completed successfully