### PR TITLE
fix: skip armor inventory resyncs in creative

### DIFF
--- a/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PaperPlayerGameListener.java
+++ b/common/src/main/java/com/hibiscusmc/hmccosmetics/listener/PaperPlayerGameListener.java
@@ -7,6 +7,7 @@ import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUsers;
 import io.papermc.paper.event.entity.EntityEquipmentChangedEvent;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -33,6 +34,10 @@ public class PaperPlayerGameListener implements Listener {
         // Selecting another hotbar slot also fires this event for the main hand. Resyncing the
         // entire inventory in that case can overwrite client-side creative inventory changes.
         if (!armorChanged) return;
+
+        // Creative inventory actions are client-authoritative. Sending the server inventory back
+        // after an armor change can overwrite the item being created or moved by the client.
+        if (player.getGameMode() == GameMode.CREATIVE) return;
 
         Bukkit.getScheduler().runTaskLater(HMCCosmeticsPlugin.getInstance(), player::updateInventory, 2);
     }


### PR DESCRIPTION
#### Select the option(s) that best describes this PR:
- [ ] Major breaking change
- [ ] Minor change
- [ ] Feature implementation
- [x] Bug fix
- [ ] Chore (Changes that don't fix or add new features *and don't* modify source files)
- [ ] Refactoring (Changes that dont't fix or add new features *but do* modify source files)
- [ ] Documentation (Changes to README files and/or JavaDocs)
- [ ] Style (Changes that don't affect the meaning of the code)
- [ ] Performance
- [ ] Other (Please specify below)

#### Please describe the changes this PR makes and why it should be merged:

Follow-up to #217.

`EntityEquipmentChangedEvent` also fires when armor is changed in creative mode. The delayed `Player#updateInventory()` then sends the server inventory over the client-authoritative creative inventory, which can remove the item the player just created or moved.

This keeps cosmetic armor updates in every game mode, but skips the full inventory resync for creative players. Non-creative armor changes still retain the resync added to prevent client desync when swapping identical armor items while a cosmetic is equipped.

#### Testing:

- Gradle 8.14.2 `clean build --offline`
- Build completed successfully and produced `HMCCosmeticsRemapped-2.9.1.jar`

#### Check that:
- [x] *Any* new classes, public methods and/or properties are properly documented with `JavaDocs`
- [x] Syntax and style are consistent with existing code
- [x] *Any* replaced method isn't deleted, but rather labeled as deprecated
> **Note** No classes or methods were added or replaced by this change.